### PR TITLE
Bridge between self JVM and real JVM

### DIFF
--- a/src/main/java/com/github/anilople/javajvm/heap/JvmClass.java
+++ b/src/main/java/com/github/anilople/javajvm/heap/JvmClass.java
@@ -133,6 +133,18 @@ public class JvmClass {
 
     /**
      *
+     * @return all field from ancestor to this class in order
+     */
+    public List<JvmField> getNonStaticJvmFieldsFromAncestorsInOrder() {
+        List<JvmField> nonStaticJvmFieldsFromAncestors = new ArrayList<>();
+        for(JvmClass jvmClass : JvmClassUtils.getInheritedClassesChain(this)) {
+            nonStaticJvmFieldsFromAncestors.addAll(jvmClass.getNonStaticFields());
+        }
+        return nonStaticJvmFieldsFromAncestors;
+    }
+
+    /**
+     *
      * @return now static fields occupy size in this class and its super classes
      */
     public int getNonStaticFieldsSize() {
@@ -144,6 +156,20 @@ public class JvmClass {
         }
 
         return number;
+    }
+
+    /**
+     *
+     * @return the non static fields of this class
+     */
+    public List<JvmField> getNonStaticFields() {
+        List<JvmField> nonStaticFields = new ArrayList<>();
+        for(JvmField jvmField : this.getJvmFields()) {
+            if(!jvmField.isStatic()) {
+                nonStaticFields.add(jvmField);
+            }
+        }
+        return nonStaticFields;
     }
 
     /**

--- a/src/main/java/com/github/anilople/javajvm/heap/JvmClass.java
+++ b/src/main/java/com/github/anilople/javajvm/heap/JvmClass.java
@@ -4,6 +4,7 @@ import com.github.anilople.javajvm.classfile.ClassFile;
 import com.github.anilople.javajvm.constants.AccessFlags;
 import com.github.anilople.javajvm.constants.SpecialMethods;
 import com.github.anilople.javajvm.runtimedataarea.LocalVariables;
+import com.github.anilople.javajvm.utils.ClassNameConverterUtils;
 import com.github.anilople.javajvm.utils.DescriptorUtils;
 import com.github.anilople.javajvm.utils.JvmClassUtils;
 import org.slf4j.Logger;
@@ -244,6 +245,16 @@ public class JvmClass {
      */
     public boolean isSameName(Class<?> clazz) {
         return this.getName().equals(JvmClassUtils.getStandardRuntimeClassName(clazz));
+    }
+
+    public Class<?> getRealClassInJvm() {
+        final String javaClassName = ClassNameConverterUtils.jvm2java(this.getName());
+        try {
+            Class<?> clazz = Class.forName(javaClassName);
+            return clazz;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/main/java/com/github/anilople/javajvm/instructions/comparisons/DCMPG.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/comparisons/DCMPG.java
@@ -13,8 +13,9 @@ public class DCMPG implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/comparisons/DCMPL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/comparisons/DCMPL.java
@@ -13,8 +13,9 @@ public class DCMPL implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/comparisons/FCMPG.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/comparisons/FCMPG.java
@@ -13,8 +13,9 @@ public class FCMPG implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/comparisons/FCMPL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/comparisons/FCMPL.java
@@ -13,8 +13,9 @@ public class FCMPL implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/constants/LDC.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/constants/LDC.java
@@ -11,6 +11,7 @@ import com.github.anilople.javajvm.runtimedataarea.reference.BaseTypeArrayRefere
 import com.github.anilople.javajvm.runtimedataarea.reference.ObjectReference;
 import com.github.anilople.javajvm.utils.ConstantPoolUtils;
 import com.github.anilople.javajvm.utils.PrimitiveTypeUtils;
+import com.github.anilople.javajvm.utils.ReferenceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,17 +76,11 @@ public class LDC implements Instruction {
                     jvmConstantString.getConstantStringInfo().getStringIndex()
             );
             logger.trace("String content = {}", utf8);
-            if(!StringPool.exists(utf8)) {
-                // load java.lang.String
-                JvmClass stringClass = jvmConstantString.getJvmClass().getLoader().loadClass(String.class);
-                ObjectReference objectReference = new ObjectReference(stringClass);
-                BaseTypeArrayReference charArrayReference = new BaseTypeArrayReference(utf8.toCharArray());
-                // use hack skill to generate string
-                objectReference.setReference(0, charArrayReference);
-                StringPool.add(utf8, objectReference);
-            }
-            // get string object from string pool
-            ObjectReference objectReference = StringPool.get(utf8);
+            // get string by tool
+            ObjectReference objectReference = ReferenceUtils.getStringObjectReference(
+                    currentClass.getLoader().loadClass(String.class),
+                    utf8
+            );
             frame.getOperandStacks().pushReference(objectReference);
 //            throw new RuntimeException("LDC now cannot support " + jvmConstant);
         } else if(jvmConstant instanceof JvmConstantClass) {

--- a/src/main/java/com/github/anilople/javajvm/instructions/constants/LDC.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/constants/LDC.java
@@ -7,8 +7,11 @@ import com.github.anilople.javajvm.heap.constant.*;
 import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
+import com.github.anilople.javajvm.runtimedataarea.Reference;
 import com.github.anilople.javajvm.runtimedataarea.reference.BaseTypeArrayReference;
+import com.github.anilople.javajvm.runtimedataarea.reference.ClassObjectReference;
 import com.github.anilople.javajvm.runtimedataarea.reference.ObjectReference;
+import com.github.anilople.javajvm.utils.ClassNameConverterUtils;
 import com.github.anilople.javajvm.utils.ConstantPoolUtils;
 import com.github.anilople.javajvm.utils.PrimitiveTypeUtils;
 import com.github.anilople.javajvm.utils.ReferenceUtils;
@@ -85,7 +88,9 @@ public class LDC implements Instruction {
 //            throw new RuntimeException("LDC now cannot support " + jvmConstant);
         } else if(jvmConstant instanceof JvmConstantClass) {
             JvmConstantClass jvmConstantClass = (JvmConstantClass) jvmConstant;
-            throw new RuntimeException("LDC now cannot support " + jvmConstantClass.getName());
+            JvmClass jvmClass = jvmConstantClass.resolveJvmClass();
+            ClassObjectReference classObjectReference = ClassObjectReference.getInstance(jvmClass);
+            frame.getOperandStacks().pushReference(classObjectReference);
         } else if(jvmConstant instanceof JvmConstantMethodType) {
             JvmConstantMethodType jvmConstantMethodType = (JvmConstantMethodType) jvmConstant;
             throw new RuntimeException("LDC now cannot support " + jvmConstantMethodType);

--- a/src/main/java/com/github/anilople/javajvm/instructions/constants/LDC_W.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/constants/LDC_W.java
@@ -20,8 +20,9 @@ public class LDC_W implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/control/DRETURN.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/control/DRETURN.java
@@ -3,7 +3,17 @@ package com.github.anilople.javajvm.instructions.control;
 import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
 
+/**
+ * Operation
+ * Return double from method
+ *
+ * Operand ..., value →
+ * Stack [empty]
+ *
+ *
+ */
 public class DRETURN implements Instruction {
 
     @Override
@@ -13,6 +23,10 @@ public class DRETURN implements Instruction {
 
     @Override
     public void execute(Frame frame) {
+        double returnValue = frame.getOperandStacks().popDoubleValue();
+        JvmThread jvmThread = frame.getJvmThread();
+        jvmThread.popFrame();
+        jvmThread.currentFrame().getOperandStacks().pushDoubleValue(returnValue);
         int nextPc = frame.getNextPc() + this.size();
         frame.setNextPc(nextPc);
     }

--- a/src/main/java/com/github/anilople/javajvm/instructions/control/FRETURN.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/control/FRETURN.java
@@ -3,7 +3,17 @@ package com.github.anilople.javajvm.instructions.control;
 import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
 
+/**
+ * Operation
+ * Return float from method
+ *
+ * Operand ..., value →
+ * Stack [empty]
+ *
+ *
+ */
 public class FRETURN implements Instruction {
 
     @Override
@@ -13,6 +23,10 @@ public class FRETURN implements Instruction {
 
     @Override
     public void execute(Frame frame) {
+        float returnValue = frame.getOperandStacks().popFloatValue();
+        JvmThread jvmThread = frame.getJvmThread();
+        jvmThread.popFrame();
+        jvmThread.currentFrame().getOperandStacks().pushFloatValue(returnValue);
         int nextPc = frame.getNextPc() + this.size();
         frame.setNextPc(nextPc);
     }

--- a/src/main/java/com/github/anilople/javajvm/instructions/control/JSR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/control/JSR.java
@@ -13,8 +13,9 @@ public class JSR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/control/LOOKUPSWITCH.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/control/LOOKUPSWITCH.java
@@ -13,8 +13,9 @@ public class LOOKUPSWITCH implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/control/LRETURN.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/control/LRETURN.java
@@ -3,7 +3,17 @@ package com.github.anilople.javajvm.instructions.control;
 import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
 
+/**
+ * Operation
+ * Return long from method
+ *
+ * Operand ..., value →
+ * Stack [empty]
+ *
+ *
+ */
 public class LRETURN implements Instruction {
 
     @Override
@@ -13,6 +23,10 @@ public class LRETURN implements Instruction {
 
     @Override
     public void execute(Frame frame) {
+        long returnValue = frame.getOperandStacks().popLongValue();
+        JvmThread jvmThread = frame.getJvmThread();
+        jvmThread.popFrame();
+        jvmThread.currentFrame().getOperandStacks().pushLongValue(returnValue);
         int nextPc = frame.getNextPc() + this.size();
         frame.setNextPc(nextPc);
     }

--- a/src/main/java/com/github/anilople/javajvm/instructions/control/RET.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/control/RET.java
@@ -13,8 +13,9 @@ public class RET implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/control/TABLESWITCH.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/control/TABLESWITCH.java
@@ -13,8 +13,9 @@ public class TABLESWITCH implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/extended/GOTO_W.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/extended/GOTO_W.java
@@ -13,8 +13,9 @@ public class GOTO_W implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/extended/IFNULL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/extended/IFNULL.java
@@ -13,8 +13,9 @@ public class IFNULL implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/extended/JSR_W.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/extended/JSR_W.java
@@ -13,8 +13,9 @@ public class JSR_W implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/extended/MULTIANEWARRAY.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/extended/MULTIANEWARRAY.java
@@ -205,7 +205,7 @@ public class MULTIANEWARRAY implements Instruction {
         } else {
             // multiple
             int headCount = counts.get(0);
-            ObjectArrayReference objectArrayReference = new ObjectArrayReference(new ObjectReference(jvmClass), headCount);
+            ObjectArrayReference objectArrayReference = new ObjectArrayReference(jvmClass, headCount);
             JvmClass subDimensionsClass = jvmClass.getLoader().loadClass(jvmClass.getName().substring(1));
             // use recursion to allocate the rest of this multiple array
             for(int i = 0; i < headCount; i++) {

--- a/src/main/java/com/github/anilople/javajvm/instructions/extended/WIDE.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/extended/WIDE.java
@@ -13,8 +13,9 @@ public class WIDE implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseand/IAND.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseand/IAND.java
@@ -4,6 +4,19 @@ import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 
+/**
+ * Operation
+ * Boolean AND int
+ *
+ * Operand ..., value1, value2 →
+ * Stack ..., result
+ *
+ * Description
+ * Both value1 and value2 must be of type int . They are popped
+ * from the operand stack. An int result is calculated by taking the
+ * bitwise AND (conjunction) of value1 and value2. The result is
+ * pushed onto the operand stack.
+ */
 public class IAND implements Instruction {
 
     @Override
@@ -13,9 +26,15 @@ public class IAND implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        throw new RuntimeException("Now cannot support " + this.getClass());
-//        int nextPc = frame.getNextPc() + this.size();
-//        frame.setNextPc(nextPc);
+        final int value2 = frame.getOperandStacks().popIntValue();
+        final int value1 = frame.getOperandStacks().popIntValue();
+
+        final int result = value1 & value2;
+
+        frame.getOperandStacks().pushIntValue(result);
+
+        int nextPc = frame.getNextPc() + this.size();
+        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseand/IAND.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseand/IAND.java
@@ -13,8 +13,9 @@ public class IAND implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseand/LAND.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseand/LAND.java
@@ -13,8 +13,9 @@ public class LAND implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseand/LAND.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseand/LAND.java
@@ -4,6 +4,19 @@ import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 
+/**
+ * Operation
+ * Boolean AND long
+ *
+ * Operand ..., value1, value2 →
+ * Stack ..., result
+ *
+ * Description
+ * Both value1 and value2 must be of type long . They are popped
+ * from the operand stack. A long result is calculated by taking the
+ * bitwise AND of value1 and value2. The result is pushed onto the
+ * operand stack.
+ */
 public class LAND implements Instruction {
 
     @Override
@@ -13,9 +26,14 @@ public class LAND implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        throw new RuntimeException("Now cannot support " + this.getClass());
-//        int nextPc = frame.getNextPc() + this.size();
-//        frame.setNextPc(nextPc);
+        final long value2 = frame.getOperandStacks().popLongValue();
+        final long value1 = frame.getOperandStacks().popLongValue();
+
+        final long result = value1 & value2;
+        frame.getOperandStacks().pushLongValue(result);
+
+        int nextPc = frame.getNextPc() + this.size();
+        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseexclusiveor/LOR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseexclusiveor/LOR.java
@@ -13,8 +13,9 @@ public class LOR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseexclusiveor/LXOR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseexclusiveor/LXOR.java
@@ -13,8 +13,9 @@ public class LXOR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseor/IOR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseor/IOR.java
@@ -13,8 +13,9 @@ public class IOR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseor/IXOR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/bitwiseor/IXOR.java
@@ -13,8 +13,9 @@ public class IXOR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/negate/DNEG.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/negate/DNEG.java
@@ -13,8 +13,9 @@ public class DNEG implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/negate/FNEG.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/negate/FNEG.java
@@ -13,8 +13,9 @@ public class FNEG implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/negate/INEG.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/negate/INEG.java
@@ -13,8 +13,9 @@ public class INEG implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/negate/LNEG.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/negate/LNEG.java
@@ -13,8 +13,9 @@ public class LNEG implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/remainder/DREM.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/remainder/DREM.java
@@ -13,8 +13,9 @@ public class DREM implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/remainder/FREM.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/remainder/FREM.java
@@ -13,8 +13,9 @@ public class FREM implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/remainder/IREM.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/remainder/IREM.java
@@ -13,8 +13,9 @@ public class IREM implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/remainder/LREM.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/remainder/LREM.java
@@ -13,8 +13,9 @@ public class LREM implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/ISHL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/ISHL.java
@@ -4,6 +4,25 @@ import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 
+/**
+ * Operation
+ * Shift left int
+ *
+ * Operand ..., value1, value2 →
+ * Stack ..., result
+ *
+ * Description
+ * Both value1 and value2 must be of type int . The values are popped
+ * from the operand stack. An int result is calculated by shifting
+ * value1 left by s bit positions, where s is the value of the low 5 bits
+ * of value2. The result is pushed onto the operand stack.
+ *
+ * Notes
+ * This is equivalent (even if overflow occurs) to multiplication by
+ * 2 to the power s. The shift distance actually used is always in the
+ * range 0 to 31, inclusive, as if value2 were subjected to a bitwise
+ * logical AND with the mask value 0x1f.
+ */
 public class ISHL implements Instruction {
 
     @Override
@@ -13,9 +32,15 @@ public class ISHL implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        throw new RuntimeException("Now cannot support " + this.getClass());
-//        int nextPc = frame.getNextPc() + this.size();
-//        frame.setNextPc(nextPc);
+        final int value2 = frame.getOperandStacks().popIntValue();
+        final int value1 = frame.getOperandStacks().popIntValue();
+
+        final int s = value2 & 0b0001_1111; // same as (value2 & 0x1f)
+        final int result = value1 << s;
+        frame.getOperandStacks().pushIntValue(result);
+
+        int nextPc = frame.getNextPc() + this.size();
+        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/ISHL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/ISHL.java
@@ -13,8 +13,9 @@ public class ISHL implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/ISHR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/ISHR.java
@@ -4,6 +4,27 @@ import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 
+/**
+ * Operation
+ * Arithmetic shift right int
+ *
+ * Operand ..., value1, value2 →
+ * Stack ..., result
+ *
+ * Description
+ * Both value1 and value2 must be of type int . The values are popped
+ * from the operand stack. An int result is calculated by shifting
+ * value1 right by s bit positions, with sign extension, where s is the
+ * value of the low 5 bits of value2. The result is pushed onto the
+ * operand stack.
+ *
+ * Notes
+ * The resulting value is floor(value1 / 2 s ), where s is value2 &
+ * 0x1f. For non-negative value1, this is equivalent to truncating int
+ * division by 2 to the power s. The shift distance actually used is
+ * always in the range 0 to 31, inclusive, as if value2 were subjected
+ * to a bitwise logical AND with the mask value 0x1f.
+ */
 public class ISHR implements Instruction {
 
     @Override
@@ -13,9 +34,15 @@ public class ISHR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        throw new RuntimeException("Now cannot support " + this.getClass());
-//        int nextPc = frame.getNextPc() + this.size();
-//        frame.setNextPc(nextPc);
+        final int value2 = frame.getOperandStacks().popIntValue();
+        final int value1 = frame.getOperandStacks().popIntValue();
+
+        final int s = value2 & 0b0001_1111; // same as (value2 & 0x1f)
+        final int result = value1 >> s; // shifting value1 right by s bit position, with sign extension
+        frame.getOperandStacks().pushIntValue(result);
+
+        int nextPc = frame.getNextPc() + this.size();
+        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/ISHR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/ISHR.java
@@ -13,8 +13,9 @@ public class ISHR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/IUSHR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/IUSHR.java
@@ -13,8 +13,9 @@ public class IUSHR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/IUSHR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/IUSHR.java
@@ -4,6 +4,28 @@ import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 
+/**
+ * Operation
+ * Logical shift right int
+ *
+ * Operand ..., result
+ * Stack ..., value1, value2 →
+ *
+ * Description
+ * Both value1 and value2 must be of type int . The values are popped
+ * from the operand stack. An int result is calculated by shifting
+ * value1 right by s bit positions, with zero extension, where s is the
+ * value of the low 5 bits of value2. The result is pushed onto the
+ * operand stack.
+ *
+ * Notes
+ * If value1 is positive and s is value2 & 0x1f, the result is the same
+ * as that of value1 >> s; if value1 is negative, the result is equal to
+ * the value of the expression (value1 >> s) + (2 << ~s). The addition
+ * of the (2 << ~s) term cancels out the propagated sign bit. The shift
+ * distance actually used is always in the range 0 to 31, inclusive.
+ *
+ */
 public class IUSHR implements Instruction {
 
     @Override
@@ -13,9 +35,15 @@ public class IUSHR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        throw new RuntimeException("Now cannot support " + this.getClass());
-//        int nextPc = frame.getNextPc() + this.size();
-//        frame.setNextPc(nextPc);
+        final int value2 = frame.getOperandStacks().popIntValue();
+        final int value1 = frame.getOperandStacks().popIntValue();
+
+        final int s = value2 & 0b0001_1111; // same as (value2 & 0x1f)
+        final int result = value1 >>> s; // shifting value1 right by s bit position, with sign extension
+        frame.getOperandStacks().pushIntValue(result);
+
+        int nextPc = frame.getNextPc() + this.size();
+        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LSHL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LSHL.java
@@ -13,8 +13,9 @@ public class LSHL implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LSHL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LSHL.java
@@ -4,6 +4,25 @@ import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 
+/**
+ * Operation
+ * Shift left long
+ *
+ * Operand ..., value1, value2 →
+ * Stack ..., result
+ *
+ * Description
+ * The value1 must be of type long , and value2 must be of type int .
+ * The values are popped from the operand stack. A long result is
+ * calculated by shifting value1 left by s bit positions, where s is the
+ * low 6 bits of value2. The result is pushed onto the operand stack.
+ *
+ * Notes
+ * This is equivalent (even if overflow occurs) to multiplication by 2
+ * to the power s. The shift distance actually used is therefore always
+ * in the range 0 to 63, inclusive, as if value2 were subjected to a
+ * bitwise logical AND with the mask value 0x3f.
+ */
 public class LSHL implements Instruction {
 
     @Override
@@ -13,9 +32,15 @@ public class LSHL implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        throw new RuntimeException("Now cannot support " + this.getClass());
-//        int nextPc = frame.getNextPc() + this.size();
-//        frame.setNextPc(nextPc);
+        final int value2 = frame.getOperandStacks().popIntValue();
+        final long value1 = frame.getOperandStacks().popLongValue();
+
+        final int s = value2 & 0b0011_1111; // same as (value2 & 0x3f)
+        final long result = value1 << s;
+        frame.getOperandStacks().pushLongValue(result);
+
+        int nextPc = frame.getNextPc() + this.size();
+        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LSHR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LSHR.java
@@ -4,6 +4,27 @@ import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 
+/**
+ * Operation
+ * Arithmetic shift right long
+ *
+ * Operand ..., value1, value2 →
+ * Stack ..., result
+ *
+ * Description
+ * The value1 must be of type long , and value2 must be of type int .
+ * The values are popped from the operand stack. A long result is
+ * calculated by shifting value1 right by s bit positions, with sign
+ * extension, where s is the value of the low 6 bits of value2. The
+ * result is pushed onto the operand stack.
+ *
+ * Notes
+ * The resulting value is floor(value1 / 2 s ), where s is value2 & 0x3f.
+ * For non-negative value1, this is equivalent to truncating long
+ * division by 2 to the power s. The shift distance actually used is
+ * therefore always in the range 0 to 63, inclusive, as if value2 were
+ * subjected to a bitwise logical AND with the mask value 0x3f.
+ */
 public class LSHR implements Instruction {
 
     @Override
@@ -13,9 +34,15 @@ public class LSHR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        throw new RuntimeException("Now cannot support " + this.getClass());
-//        int nextPc = frame.getNextPc() + this.size();
-//        frame.setNextPc(nextPc);
+        final int value2 = frame.getOperandStacks().popIntValue();
+        final long value1 = frame.getOperandStacks().popLongValue();
+
+        final int s = value2 & 0b0011_1111; // same as (value2 & 0x3f)
+        final long result = value1 >> s;
+        frame.getOperandStacks().pushLongValue(result);
+
+        int nextPc = frame.getNextPc() + this.size();
+        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LSHR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LSHR.java
@@ -13,8 +13,9 @@ public class LSHR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LUSHR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LUSHR.java
@@ -4,6 +4,27 @@ import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 
+/**
+ * Operation
+ * Logical shift right long
+ *
+ * Operand ..., value1, value2 →
+ * Stack ..., result
+ *
+ * Description
+ * The value1 must be of type long , and value2 must be of type int .
+ * The values are popped from the operand stack. A long result is
+ * calculated by shifting value1 right logically by s bit positions, with
+ * zero extension, where s is the value of the low 6 bits of value2.
+ * The result is pushed onto the operand stack.
+ *
+ * Notes
+ * If value1 is positive and s is value2 & 0x3f, the result is the same
+ * as that of value1 >> s; if value1 is negative, the result is equal to the
+ * value of the expression (value1 >> s) + (2L << ~s). The addition of
+ * the (2L << ~s) term cancels out the propagated sign bit. The shift
+ * distance actually used is always in the range 0 to 63, inclusive.
+ */
 public class LUSHR implements Instruction {
 
     @Override
@@ -11,11 +32,18 @@ public class LUSHR implements Instruction {
 
     }
 
+
     @Override
     public void execute(Frame frame) {
-        throw new RuntimeException("Now cannot support " + this.getClass());
-//        int nextPc = frame.getNextPc() + this.size();
-//        frame.setNextPc(nextPc);
+        final int value2 = frame.getOperandStacks().popIntValue();
+        final long value1 = frame.getOperandStacks().popLongValue();
+
+        final int s = value2 & 0b0011_1111; // same as (value2 & 0x3f)
+        final long result = value1 >>> s;
+        frame.getOperandStacks().pushLongValue(result);
+
+        int nextPc = frame.getNextPc() + this.size();
+        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LUSHR.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/math/shift/LUSHR.java
@@ -13,8 +13,9 @@ public class LUSHR implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/ANEWARRAY.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/ANEWARRAY.java
@@ -101,8 +101,7 @@ public class ANEWARRAY implements Instruction {
      * @return
      */
     public static ObjectArrayReference allocate(JvmClass jvmClass, int count) {
-        ObjectReference objectReference = new ObjectReference(jvmClass);
-        ObjectArrayReference objectArrayReference = new ObjectArrayReference(objectReference, count);
+        ObjectArrayReference objectArrayReference = new ObjectArrayReference(jvmClass, count);
         return objectArrayReference;
     }
 }

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/ATHROW.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/ATHROW.java
@@ -13,8 +13,9 @@ public class ATHROW implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/INSTANCEOF.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/INSTANCEOF.java
@@ -13,8 +13,9 @@ public class INSTANCEOF implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKEDYNAMIC.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKEDYNAMIC.java
@@ -13,8 +13,9 @@ public class INVOKEDYNAMIC implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKEINTERFACE.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKEINTERFACE.java
@@ -13,8 +13,9 @@ public class INVOKEINTERFACE implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKESPECIAL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKESPECIAL.java
@@ -83,6 +83,7 @@ public class INVOKESPECIAL implements Instruction {
 
         // use hack skill
         if(HackUtils.isInHackMethods(jvmMethod)) {
+            HackUtils.hackMethod(frame, jvmMethod, localVariables);
             // early return here
             int nextPc = frame.getNextPc() + this.size();
             frame.setNextPc(nextPc);

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKESTATIC.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKESTATIC.java
@@ -60,6 +60,7 @@ public class INVOKESTATIC implements Instruction {
 
         // use hack skill
         if(HackUtils.isInHackMethods(jvmMethod)) {
+            HackUtils.hackStaticNativeMethod(jvmMethod, localVariables);
             // early return here
             int nextPc = frame.getNextPc() + this.size();
             frame.setNextPc(nextPc);

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKESTATIC.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKESTATIC.java
@@ -1,14 +1,11 @@
 package com.github.anilople.javajvm.instructions.references;
 
-import com.github.anilople.javajvm.constants.Descriptors;
 import com.github.anilople.javajvm.heap.JvmMethod;
 import com.github.anilople.javajvm.heap.constant.JvmConstantMethodref;
 import com.github.anilople.javajvm.instructions.BytecodeReader;
 import com.github.anilople.javajvm.instructions.Instruction;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 import com.github.anilople.javajvm.runtimedataarea.LocalVariables;
-import com.github.anilople.javajvm.runtimedataarea.Reference;
-import com.github.anilople.javajvm.runtimedataarea.reference.ObjectReference;
 import com.github.anilople.javajvm.utils.ByteUtils;
 import com.github.anilople.javajvm.utils.DescriptorUtils;
 import com.github.anilople.javajvm.utils.HackUtils;
@@ -16,7 +13,6 @@ import com.github.anilople.javajvm.utils.PrimitiveTypeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.List;
 
 public class INVOKESTATIC implements Instruction {
@@ -60,7 +56,7 @@ public class INVOKESTATIC implements Instruction {
 
         // use hack skill
         if(HackUtils.isInHackMethods(jvmMethod)) {
-            HackUtils.hackStaticNativeMethod(jvmMethod, localVariables);
+            HackUtils.hackMethod(frame, jvmMethod, localVariables);
             // early return here
             int nextPc = frame.getNextPc() + this.size();
             frame.setNextPc(nextPc);

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKEVIRTUAL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKEVIRTUAL.java
@@ -83,7 +83,7 @@ public class INVOKEVIRTUAL implements Instruction {
         // use hack skill
         if(HackUtils.isInHackMethods(jvmMethod)) {
             // hack with System.out
-            HackUtils.hackSystemOut(jvmMethod, localVariables);
+            HackUtils.hackNativeMethod(jvmMethod, localVariables);
             // early return here
             int nextPc = frame.getNextPc() + this.size();
             frame.setNextPc(nextPc);

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKEVIRTUAL.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/INVOKEVIRTUAL.java
@@ -83,7 +83,7 @@ public class INVOKEVIRTUAL implements Instruction {
         // use hack skill
         if(HackUtils.isInHackMethods(jvmMethod)) {
             // hack with System.out
-            HackUtils.hackNativeMethod(jvmMethod, localVariables);
+            HackUtils.hackMethod(frame, jvmMethod, localVariables);
             // early return here
             int nextPc = frame.getNextPc() + this.size();
             frame.setNextPc(nextPc);

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/MONITORENTER.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/MONITORENTER.java
@@ -13,8 +13,9 @@ public class MONITORENTER implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/MONITOREXIT.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/MONITOREXIT.java
@@ -13,8 +13,9 @@ public class MONITOREXIT implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/reserved/BREAKPOINT.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/reserved/BREAKPOINT.java
@@ -13,8 +13,9 @@ public class BREAKPOINT implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/reserved/IMPDEP1.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/reserved/IMPDEP1.java
@@ -13,8 +13,9 @@ public class IMPDEP1 implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/reserved/IMPDEP2.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/reserved/IMPDEP2.java
@@ -13,8 +13,9 @@ public class IMPDEP2 implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/stack/DUP2.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/stack/DUP2.java
@@ -13,8 +13,9 @@ public class DUP2 implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/stack/DUP2_X1.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/stack/DUP2_X1.java
@@ -13,8 +13,9 @@ public class DUP2_X1 implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/stack/DUP2_X2.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/stack/DUP2_X2.java
@@ -13,8 +13,9 @@ public class DUP2_X2 implements Instruction {
 
     @Override
     public void execute(Frame frame) {
-        int nextPc = frame.getNextPc() + this.size();
-        frame.setNextPc(nextPc);
+        throw new RuntimeException("Now cannot support " + this.getClass());
+//        int nextPc = frame.getNextPc() + this.size();
+//        frame.setNextPc(nextPc);
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/instructions/stores/AASTORE.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/stores/AASTORE.java
@@ -55,7 +55,7 @@ public class AASTORE implements Instruction {
 
         // type check here, jvms8: Page 368
         // null do not need to type check
-        logger.trace("value, i.e source = {}, array component of reference type target = {}", value, objectArrayReference.getComponentTypeReference());
+        logger.trace("value, i.e source = {}, array component of reference type target = {}", value, objectArrayReference.getComponentType());
         if(!Reference.NULL.equals(value)) {
             // to do
 

--- a/src/main/java/com/github/anilople/javajvm/instructions/stores/AASTORE.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/stores/AASTORE.java
@@ -55,7 +55,7 @@ public class AASTORE implements Instruction {
 
         // type check here, jvms8: Page 368
         // null do not need to type check
-        logger.trace("value, i.e source = {}, array component of reference type target = {}", value, objectArrayReference.getTypeReference());
+        logger.trace("value, i.e source = {}, array component of reference type target = {}", value, objectArrayReference.getComponentTypeReference());
         if(!Reference.NULL.equals(value)) {
             // to do
 

--- a/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/BaseTypeArrayReference.java
+++ b/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/BaseTypeArrayReference.java
@@ -154,6 +154,10 @@ public class BaseTypeArrayReference extends ArrayReference {
         return "BaseTypeArrayReference{" + value + "}";
     }
 
+    public byte getTypeCode() {
+        return typeCode;
+    }
+
     public boolean isBooleanType() {
         return typeCode == ArrayTypeCodes.T_BOOLEAN;
     }

--- a/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/BaseTypeArrayReference.java
+++ b/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/BaseTypeArrayReference.java
@@ -67,6 +67,24 @@ public class BaseTypeArrayReference extends ArrayReference {
         }
     }
 
+    public BaseTypeArrayReference(boolean[] booleans) {
+        super(booleans.length);
+        this.typeCode = ArrayTypeCodes.T_BOOLEAN;
+        this.booleans = booleans;
+    }
+
+    public BaseTypeArrayReference(byte[] bytes) {
+        super(bytes.length);
+        this.typeCode = ArrayTypeCodes.T_BYTE;
+        this.bytes = bytes;
+    }
+
+    public BaseTypeArrayReference(short[] shorts) {
+        super(shorts.length);
+        this.typeCode = ArrayTypeCodes.T_SHORT;
+        this.shorts = shorts;
+    }
+
     /**
      * construct from char array
      * @param chars
@@ -76,6 +94,31 @@ public class BaseTypeArrayReference extends ArrayReference {
         this.typeCode = ArrayTypeCodes.T_CHAR;
         this.chars = chars;
     }
+
+    public BaseTypeArrayReference(int[] ints) {
+        super(ints.length);
+        this.typeCode = ArrayTypeCodes.T_INT;
+        this.ints = ints;
+    }
+
+    public BaseTypeArrayReference(float[] floats) {
+        super(floats.length);
+        this.typeCode = ArrayTypeCodes.T_FLOAT;
+        this.floats = floats;
+    }
+
+    public BaseTypeArrayReference(long[] longs) {
+        super(longs.length);
+        this.typeCode = ArrayTypeCodes.T_LONG;
+        this.longs = longs;
+    }
+
+    public BaseTypeArrayReference(double[] doubles) {
+        super(doubles.length);
+        this.typeCode = ArrayTypeCodes.T_DOUBLE;
+        this.doubles = doubles;
+    }
+
 
     @Override
     public String toString() {

--- a/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/ClassObjectReference.java
+++ b/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/ClassObjectReference.java
@@ -1,0 +1,88 @@
+package com.github.anilople.javajvm.runtimedataarea.reference;
+
+import com.github.anilople.javajvm.heap.JvmClass;
+import com.github.anilople.javajvm.utils.ReferenceUtils;
+import com.github.anilople.javajvm.utils.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * represents
+ * @see java.lang.Class
+ *
+ * This class is per to per with java.lang.Class in real jvm
+ */
+public class ClassObjectReference extends ObjectReference {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClassObjectReference.class);
+
+    /**
+     * memory class
+     */
+    private static final Map<Class<?>, ClassObjectReference> class2ClassObjectReference = new ConcurrentHashMap<>();
+
+    private static final Map<ClassObjectReference, Class<?>> classObjectReference2Class = new ConcurrentHashMap<>();
+
+    /**
+     * Remember that new java.lang.Class() is forbidden,
+     * so the initialize must be manual!
+     * @param jvmClass must represents java.lang.Class
+     * @param clazz
+     */
+    private ClassObjectReference(JvmClass jvmClass, Class<?> clazz) {
+        super(jvmClass);
+        if (!jvmClass.isSameName(Class.class)) {
+            throw new RuntimeException(jvmClass.getName() + "'s type is not java.lang.Class");
+        }
+        // hack the name
+        ObjectReference stringReference = ReferenceUtils.getStringObjectReference(
+                jvmClass.getLoader().loadClass(String.class),
+                clazz.getName()
+        );
+        int nameOffset = ReflectionUtils.getNonStaticOffset(Class.class, "name");
+        this.setReference(nameOffset, stringReference);
+    }
+
+    /**
+     *
+     * @param jvmClass represents {@code Class<String>}, {@code Class<Object>}, int.class, void.class, etc..
+     * @return self-define ClassObjectReference
+     */
+    public static ClassObjectReference getInstance(JvmClass jvmClass) {
+        // which java.lang.Class<?> this JvmClass should be
+        final Class<?> clazz = jvmClass.getRealClassInJvm();
+        // do not consider concurrent problem
+        if(!class2ClassObjectReference.containsKey(clazz)) {
+            logger.debug("{} not exists, now try to add it.", clazz);
+            // it is special, because we want the object reference to java.lang.Class
+            final JvmClass classJvmClass = jvmClass.getLoader().loadClass(Class.class);
+            ClassObjectReference classObjectReference = new ClassObjectReference(classJvmClass, clazz);
+            class2ClassObjectReference.put(clazz, classObjectReference);
+            classObjectReference2Class.put(classObjectReference, clazz);
+        }
+        return class2ClassObjectReference.get(clazz);
+    }
+
+    /**
+     * sometimes we want to know, if give a {@code ClassObjectReference},
+     * which {@code Class<?>} it represents?
+     * this method will tell you.
+     * @param classObjectReference
+     * @return
+     */
+    public static Class<?> getRealClassInJvm(ClassObjectReference classObjectReference) {
+        if(!classObjectReference2Class.containsKey(classObjectReference)) {
+            throw new RuntimeException(classObjectReference + " not exist");
+        }
+        return classObjectReference2Class.get(classObjectReference);
+    }
+
+    @Override
+    public String toString() {
+        Class<?> clazz = classObjectReference2Class.get(this);
+        return "ClassObjectReference{" + clazz + "}";
+    }
+}

--- a/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/ObjectArrayReference.java
+++ b/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/ObjectArrayReference.java
@@ -6,7 +6,11 @@ import java.util.Arrays;
 
 public class ObjectArrayReference extends ArrayReference {
 
-    private Reference typeReference;
+    /**
+     * array exists component,
+     * this field represents the type of component
+     */
+    private Reference componentTypeReference;
 
     /**
      * reference
@@ -14,21 +18,21 @@ public class ObjectArrayReference extends ArrayReference {
     private Reference[] references;
 
 
-    public ObjectArrayReference(Reference typeReference, int count) {
+    public ObjectArrayReference(Reference componentTypeReference, int count) {
         super(count);
-        this.typeReference = typeReference;
+        this.componentTypeReference = componentTypeReference;
         references = new Reference[count];
         Arrays.fill(references, Reference.NULL);
     }
 
-    public Reference getTypeReference() {
-        return typeReference;
+    public Reference getComponentTypeReference() {
+        return componentTypeReference;
     }
 
     @Override
     public String toString() {
         return "ObjectArrayReference{" +
-                "typeReference=" + typeReference +
+                "typeReference=" + componentTypeReference +
                 ", references=" + Arrays.toString(references) +
                 '}';
     }

--- a/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/ObjectArrayReference.java
+++ b/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/ObjectArrayReference.java
@@ -1,5 +1,6 @@
 package com.github.anilople.javajvm.runtimedataarea.reference;
 
+import com.github.anilople.javajvm.heap.JvmClass;
 import com.github.anilople.javajvm.runtimedataarea.Reference;
 
 import java.util.Arrays;
@@ -10,7 +11,7 @@ public class ObjectArrayReference extends ArrayReference {
      * array exists component,
      * this field represents the type of component
      */
-    private Reference componentTypeReference;
+    private JvmClass componentType;
 
     /**
      * reference
@@ -18,21 +19,21 @@ public class ObjectArrayReference extends ArrayReference {
     private Reference[] references;
 
 
-    public ObjectArrayReference(Reference componentTypeReference, int count) {
+    public ObjectArrayReference(JvmClass componentType, int count) {
         super(count);
-        this.componentTypeReference = componentTypeReference;
+        this.componentType = componentType;
         references = new Reference[count];
         Arrays.fill(references, Reference.NULL);
     }
 
-    public Reference getComponentTypeReference() {
-        return componentTypeReference;
+    public JvmClass getComponentType() {
+        return componentType;
     }
 
     @Override
     public String toString() {
         return "ObjectArrayReference{" +
-                "typeReference=" + componentTypeReference +
+                "typeReference=" + componentType +
                 ", references=" + Arrays.toString(references) +
                 '}';
     }

--- a/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/ObjectReference.java
+++ b/src/main/java/com/github/anilople/javajvm/runtimedataarea/reference/ObjectReference.java
@@ -1,17 +1,71 @@
 package com.github.anilople.javajvm.runtimedataarea.reference;
 
 import com.github.anilople.javajvm.heap.JvmClass;
+import com.github.anilople.javajvm.heap.JvmField;
 import com.github.anilople.javajvm.runtimedataarea.LocalVariables;
 import com.github.anilople.javajvm.runtimedataarea.Reference;
+import com.github.anilople.javajvm.utils.DescriptorUtils;
+
+import java.util.List;
+
+import static com.github.anilople.javajvm.constants.Descriptors.BaseType.*;
+import static com.github.anilople.javajvm.constants.Descriptors.BaseType.BOOLEAN;
 
 public class ObjectReference extends LocalVariables implements Reference {
 
     private JvmClass jvmClass;
 
+    /**
+     * Initialize an object reference,
+     * The default value of type,
+     * jls8, 4.12.5 Initial Values of Variables, Page 87
+     * @param jvmClass object ref's class
+     */
     public ObjectReference(JvmClass jvmClass) {
         // an Object in run-time exist own fields (non static fields)
         super(jvmClass.getNonStaticFieldsSize());
         this.jvmClass = jvmClass;
+
+        // initial fields with default value
+        List<JvmField> jvmFields = jvmClass.getNonStaticJvmFieldsFromAncestorsInOrder();
+        int fieldOffset = 0;
+        for(JvmField jvmField : jvmFields) {
+            // initial default value of this field
+            String descriptor = jvmField.getDescriptor();
+            if(DescriptorUtils.isBaseType(descriptor)) {
+                switch (descriptor) {
+                    case BYTE:
+                        this.setByteValue(fieldOffset, (byte) 0);
+                        break;
+                    case CHAR:
+                        this.setCharValue(fieldOffset, '\u0000');
+                        break;
+                    case DOUBLE:
+                        this.setDoubleValue(fieldOffset, 0.0d);
+                        break;
+                    case FLOAT:
+                        this.setFloatValue(fieldOffset, 0.0f);
+                        break;
+                    case INT:
+                        this.setIntValue(fieldOffset, 0);
+                        break;
+                    case LONG:
+                        this.setLongValue(fieldOffset, 0L);
+                        break;
+                    case SHORT:
+                        this.setShortValue(fieldOffset, (short) 0);
+                        break;
+                    case BOOLEAN:
+                        this.setBooleanValue(fieldOffset, false);
+                        break;
+                }
+            } else {
+                this.setReference(fieldOffset, Reference.NULL);
+            }
+
+            // add the offset
+            fieldOffset += jvmField.getSize();
+        }
     }
 
     @Override

--- a/src/main/java/com/github/anilople/javajvm/utils/ClassNameConverterUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/ClassNameConverterUtils.java
@@ -1,0 +1,34 @@
+package com.github.anilople.javajvm.utils;
+
+/**
+ * a class exists 2 different names between Java level and JVM level
+ *
+ * Example:
+ *      Java level          JVM level
+ *      java.lang.Object    java/lang/Object
+ *      java.lang.String    java/lang/String
+ */
+public class ClassNameConverterUtils {
+
+    /**
+     * java/lang/Object -> java.lang.Object
+     * @param jvmClassName
+     * @return
+     */
+    public static String jvm2java(String jvmClassName) {
+        return jvmClassName.replace('/', '.');
+    }
+
+    /**
+     * java.lang.Object -> java/lang/Object
+     * @param javaClassName
+     * @return
+     */
+    public static String java2jvm(String javaClassName) {
+        return javaClassName.replace('.', '/');
+    }
+
+    public static String java2jvm(Class<?> clazz) {
+        return java2jvm(clazz.getName());
+    }
+}

--- a/src/main/java/com/github/anilople/javajvm/utils/DescriptorUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/DescriptorUtils.java
@@ -465,4 +465,108 @@ public class DescriptorUtils {
         }
         return dimensions;
     }
+
+    /**
+     * MethodDescriptor:
+     *      ( {ParameterDescriptor} ) ReturnDescriptor
+     * from ParameterDescriptor, generate the ParameterTypes in Method
+     * @see java.lang.reflect.Method
+     * @param methodDescriptor
+     * @return
+     */
+    public static Class<?>[] methodDescriptor2ParameterTypes(String methodDescriptor) {
+        List<String> parameterDescriptor = getParameterDescriptor(methodDescriptor);
+        // base type, array, or reference
+        Class<?>[] classes = new Class<?>[parameterDescriptor.size()];
+        for(int i = 0; i < parameterDescriptor.size(); i++) {
+            String descriptor = parameterDescriptor.get(i);
+            classes[i] = fieldTypeDescriptor2Class(descriptor);
+        }
+        return classes;
+    }
+
+    /**
+     * FieldType:
+     *      BaseType
+     *      ObjectType
+     *      ArrayType
+     * @param fieldTypeDescriptor
+     * @return
+     */
+    public static Class<?> fieldTypeDescriptor2Class(String fieldTypeDescriptor) {
+        assert isFieldType(fieldTypeDescriptor);
+        if(isBaseType(fieldTypeDescriptor)) {
+            return baseTypeDescriptor2Class(fieldTypeDescriptor);
+        } else if(isArrayType(fieldTypeDescriptor)) {
+            return arrayTypeDescriptor2Class(fieldTypeDescriptor);
+        } else if(isObjectType(fieldTypeDescriptor)) {
+            return objectTypeDescriptor2Class(fieldTypeDescriptor);
+        } else {
+            throw new RuntimeException(fieldTypeDescriptor + " cannot be recognized");
+        }
+    }
+
+    /**
+     * I -> int.class
+     * Z -> boolean.class
+     * etc.
+     * @param baseTypeDescriptor JVM level descriptor
+     * @return
+     */
+    static Class<?> baseTypeDescriptor2Class(String baseTypeDescriptor) {
+        assert isBaseType(baseTypeDescriptor);
+        switch (baseTypeDescriptor) {
+            case Descriptors.BaseType.BOOLEAN:
+                return boolean.class;
+            case Descriptors.BaseType.BYTE:
+                return byte.class;
+            case Descriptors.BaseType.SHORT:
+                return short.class;
+            case Descriptors.BaseType.CHAR:
+                return char.class;
+            case Descriptors.BaseType.INT:
+                return int.class;
+            case Descriptors.BaseType.LONG:
+                return long.class;
+            case Descriptors.BaseType.FLOAT:
+                return float.class;
+            case Descriptors.BaseType.DOUBLE:
+                return double.class;
+            default:
+                throw new IllegalStateException("Unexpected value: " + baseTypeDescriptor);
+        }
+    }
+
+    /**
+     * [[I -> int[][].class
+     * etc.
+     * @param arrayTypeDescriptor JVM level descriptor
+     * @return
+     */
+    static Class<?> arrayTypeDescriptor2Class(String arrayTypeDescriptor) {
+        assert isArrayType(arrayTypeDescriptor);
+        final String javaLevelArrayTypeDescriptor = ClassNameConverterUtils.jvm2java(arrayTypeDescriptor);
+        try {
+            return Class.forName(javaLevelArrayTypeDescriptor);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Ljava/lang/Object; -> Object.class
+     * etc.
+     * @param objectTypeDescriptor JVM level descriptor
+     * @return
+     */
+    static Class<?> objectTypeDescriptor2Class(String objectTypeDescriptor) {
+        assert isObjectType(objectTypeDescriptor);
+        final String jvmLevelClassName = getClassName(objectTypeDescriptor);
+        final String javaLevelClassName = ClassNameConverterUtils.jvm2java(jvmLevelClassName);
+        try {
+            return Class.forName(javaLevelClassName);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/github/anilople/javajvm/utils/HackUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/HackUtils.java
@@ -35,8 +35,15 @@ public class HackUtils {
                     jvmMethod.getDescriptor()
             );
         }
-        return jvmMethod.getJvmClass().isSameName(PrintStream.class)
-                || (jvmMethod.getJvmClass().isSameName(Class.class) && jvmMethod.isNative());
+        if(jvmMethod.getJvmClass().isSameName(PrintStream.class)) {
+            return true;
+        }
+        if(jvmMethod.getJvmClass().isSameName(Class.class) && jvmMethod.isNative()) {
+            return true;
+        }
+
+        // default action: hack all native method
+        return jvmMethod.isNative();
     }
 
     /**
@@ -50,9 +57,8 @@ public class HackUtils {
         if(jvmMethod.getJvmClass().isSameName(PrintStream.class)) {
             // System.out
             hackSystemOut(jvmMethod, localVariables);
-        }
-        if(jvmMethod.getJvmClass().isSameName(Class.class)) {
-            // java.lang.Class
+        } else {
+            // default action: hack all native method
             try {
                 hackAllNativeMethod(frame, jvmMethod, localVariables);
             } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {

--- a/src/main/java/com/github/anilople/javajvm/utils/HackUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/HackUtils.java
@@ -5,6 +5,7 @@ import com.github.anilople.javajvm.heap.JvmClassLoader;
 import com.github.anilople.javajvm.heap.JvmMethod;
 import com.github.anilople.javajvm.runtimedataarea.Frame;
 import com.github.anilople.javajvm.runtimedataarea.LocalVariables;
+import com.github.anilople.javajvm.runtimedataarea.OperandStacks;
 import com.github.anilople.javajvm.runtimedataarea.Reference;
 import com.github.anilople.javajvm.runtimedataarea.reference.BaseTypeArrayReference;
 import com.github.anilople.javajvm.runtimedataarea.reference.NullReference;
@@ -224,11 +225,59 @@ public class HackUtils {
             returnObject = method.invoke(thisObject, parameterObjects);
         }
 
-        if(!void.class.equals(method.getReturnType())) {
+        final Class<?> returnType = method.getReturnType();
+        if(!void.class.equals(returnType)) {
             // exists return value
-            Reference returnReference = ReferenceUtils.object2Reference(jvmClassLoader, returnObject);
-            // push the result
-            frame.getOperandStacks().pushReference(returnReference);
+            if(returnType.isPrimitive()) {
+                // int, boolean, double etc..
+                pushPrimitiveValueByType(frame.getOperandStacks(), returnObject, returnType);
+            } else {
+                // String, Object, String[][] etc..
+                Reference returnReference = ReferenceUtils.object2Reference(jvmClassLoader, returnObject);
+                // push the result
+                frame.getOperandStacks().pushReference(returnReference);
+            }
+        }
+    }
+
+    /**
+     * push the return value of method to operand stack
+     * when return value is primitive type
+     * @param operandStacks
+     * @param primitiveValue
+     * @param primitiveType
+     */
+    private static void pushPrimitiveValueByType(OperandStacks operandStacks, Object primitiveValue, Class<?> primitiveType) {
+        if(!primitiveType.isPrimitive()) {
+            throw new RuntimeException(primitiveType + " is not primitive");
+        }
+        final Class<?> type = primitiveType;
+        if(type.equals(boolean.class)) {
+            boolean value = (boolean) primitiveValue;
+            operandStacks.pushBooleanValue(value);
+        } else if(type.equals(byte.class)) {
+            byte value = (byte) primitiveValue;
+            operandStacks.pushByteValue(value);
+        } else if(type.equals(short.class)) {
+            short value = (short) primitiveValue;
+            operandStacks.pushShortValue(value);
+        } else if(type.equals(char.class)) {
+            char value = (char) primitiveValue;
+            operandStacks.pushCharValue(value);
+        } else if(type.equals(int.class)) {
+            int value = (int) primitiveValue;
+            operandStacks.pushIntValue(value);
+        } else if(type.equals(float.class)) {
+            float value = (float) primitiveValue;
+            operandStacks.pushFloatValue(value);
+        } else if(type.equals(long.class)) {
+            long value = (long) primitiveValue;
+            operandStacks.pushLongValue(value);
+        } else if(type.equals(double.class)) {
+            double value = (double) primitiveValue;
+            operandStacks.pushDoubleValue(value);
+        } else {
+            throw new IllegalArgumentException("Cannot set type " + type);
         }
     }
 

--- a/src/main/java/com/github/anilople/javajvm/utils/HackUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/HackUtils.java
@@ -7,6 +7,7 @@ import com.github.anilople.javajvm.runtimedataarea.Frame;
 import com.github.anilople.javajvm.runtimedataarea.LocalVariables;
 import com.github.anilople.javajvm.runtimedataarea.OperandStacks;
 import com.github.anilople.javajvm.runtimedataarea.Reference;
+import com.github.anilople.javajvm.runtimedataarea.reference.ArrayReference;
 import com.github.anilople.javajvm.runtimedataarea.reference.BaseTypeArrayReference;
 import com.github.anilople.javajvm.runtimedataarea.reference.NullReference;
 import com.github.anilople.javajvm.runtimedataarea.reference.ObjectReference;
@@ -58,6 +59,8 @@ public class HackUtils {
         if(jvmMethod.getJvmClass().isSameName(PrintStream.class)) {
             // System.out
             hackSystemOut(jvmMethod, localVariables);
+        } else if(jvmMethod.getJvmClass().isSameName(System.class) && jvmMethod.getName().equals("arraycopy")) {
+            hackSystemArrayCopy(localVariables);
         } else {
             // default action: hack all native method
             try {
@@ -171,6 +174,19 @@ public class HackUtils {
             default:
                 throw new IllegalStateException("Unexpected value: " + parameterDescriptor);
         }
+    }
+
+    /**
+     * @see java.lang.System arraycopy method
+     * @param localVariables
+     */
+    private static void hackSystemArrayCopy(LocalVariables localVariables) {
+        ArrayReference srcArrayReference = (ArrayReference) localVariables.getReference(0);
+        int srcPos = localVariables.getIntValue(1);
+        ArrayReference destArrayReference = (ArrayReference) localVariables.getReference(2);
+        int destPos = localVariables.getIntValue(3);
+        int length = localVariables.getIntValue(4);
+        ReferenceUtils.arrayCopy(srcArrayReference, srcPos, destArrayReference, destPos, length);
     }
 
     public static void assertNativeMethod(JvmMethod jvmMethod) {

--- a/src/main/java/com/github/anilople/javajvm/utils/HackUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/HackUtils.java
@@ -34,6 +34,30 @@ public class HackUtils {
     }
 
     /**
+     * hack a non-static native method
+     * @param jvmMethod must be native method
+     * @param localVariables args pop from operand stack
+     * @return
+     */
+    public static Reference hackNativeMethod(JvmMethod jvmMethod, LocalVariables localVariables) {
+        if(jvmMethod.getJvmClass().isSameName(PrintStream.class)) {
+            // System.out
+            hackSystemOut(jvmMethod, localVariables);
+        }
+        return null;
+    }
+
+    /**
+     * hack a static native method
+     * @param jvmMethod must be native method
+     * @param localVariables args pop from operand stack
+     * @return
+     */
+    public static Reference hackStaticNativeMethod(JvmMethod jvmMethod, LocalVariables localVariables) {
+        return null;
+    }
+
+    /**
      * Hack the method in class System.out, i.e PrintStream
      * @see java.io.PrintStream;
      * @param jvmMethod method in runtime

--- a/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
@@ -1,0 +1,36 @@
+package com.github.anilople.javajvm.utils;
+
+import com.github.anilople.javajvm.cachepool.StringPool;
+import com.github.anilople.javajvm.heap.JvmClass;
+import com.github.anilople.javajvm.runtimedataarea.reference.BaseTypeArrayReference;
+import com.github.anilople.javajvm.runtimedataarea.reference.ObjectReference;
+
+/**
+ * A bridge between real java object and self-define reference
+ */
+public class ReferenceUtils {
+
+    /**
+     * get the string.
+     * use pool to save string
+     * @param stringClass must be string class
+     * @param utf8 string's content
+     * @return object reference of string
+     */
+    public static ObjectReference getStringObjectReference(JvmClass stringClass, String utf8) {
+        if(!stringClass.isSameName(String.class)) {
+            throw new RuntimeException(stringClass.getName() + " is not " + String.class);
+        }
+        // exists in pool or not
+        if(!StringPool.exists(utf8)) {
+            ObjectReference objectReference = new ObjectReference(stringClass);
+            BaseTypeArrayReference charArrayReference = new BaseTypeArrayReference(utf8.toCharArray());
+            // use hack skill to generate string
+            objectReference.setReference(0, charArrayReference);
+            StringPool.add(utf8, objectReference);
+        }
+        // get string from pool
+        return StringPool.get(utf8);
+    }
+
+}

--- a/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
@@ -2,8 +2,19 @@ package com.github.anilople.javajvm.utils;
 
 import com.github.anilople.javajvm.cachepool.StringPool;
 import com.github.anilople.javajvm.heap.JvmClass;
+import com.github.anilople.javajvm.heap.JvmClassLoader;
+import com.github.anilople.javajvm.runtimedataarea.LocalVariables;
+import com.github.anilople.javajvm.runtimedataarea.Reference;
+import com.github.anilople.javajvm.runtimedataarea.reference.ArrayReference;
 import com.github.anilople.javajvm.runtimedataarea.reference.BaseTypeArrayReference;
+import com.github.anilople.javajvm.runtimedataarea.reference.ObjectArrayReference;
 import com.github.anilople.javajvm.runtimedataarea.reference.ObjectReference;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A bridge between real java object and self-define reference
@@ -33,4 +44,289 @@ public class ReferenceUtils {
         return StringPool.get(utf8);
     }
 
+
+    /**
+     * convert a real object in JVM to
+     * self-define reference
+     * @param jvmClassLoader
+     * @param object
+     * @return
+     */
+    public static Reference object2Reference(JvmClassLoader jvmClassLoader, Object object) throws IllegalAccessException {
+        if(null == object) {
+            return Reference.NULL;
+        }
+        final Class<?> clazz = object.getClass();
+        // array
+        if(clazz.isArray()) {
+            return array2ArrayReference(jvmClassLoader, object);
+        }
+
+        // object
+
+        // get the JvmClass of object
+        JvmClass jvmClass = jvmClassLoader.loadClass(clazz);
+        ObjectReference objectReference = new ObjectReference(jvmClass);
+
+        // converter the static fields, todo
+
+        // converter the non-static fields
+        List<Field> nonStaticFields = getNonStaticFieldsFromAncestor(clazz);
+        int nonStaticFieldCurrentOffset = 0;
+        for(Field nonStaticField : nonStaticFields) {
+            if(nonStaticField.getType().isPrimitive()) {
+                setPrimitiveType(objectReference, nonStaticFieldCurrentOffset, object, nonStaticField);
+            } else {
+                setReferenceType(objectReference, nonStaticFieldCurrentOffset, jvmClassLoader, object, nonStaticField);
+            }
+            nonStaticFieldCurrentOffset += getFieldSize(nonStaticField);
+        }
+
+        return objectReference;
+    }
+
+    /**
+     * convert an array object to self-define array reference
+     * @param arrayObject array
+     * @return array reference
+     */
+    public static ArrayReference array2ArrayReference(
+            JvmClassLoader jvmClassLoader, Object arrayObject
+    ) throws IllegalAccessException {
+        int dimensions = DescriptorUtils.getDimensions(arrayObject.getClass().getName());
+        if(dimensions <= 0) {
+            throw new RuntimeException(arrayObject + " is not array");
+        }
+        if(1 == dimensions) {
+            // end the recursion
+            final Class<?> componentType = arrayObject.getClass().getComponentType();
+            if(componentType.isPrimitive()) {
+                return singleDimensionPrimitiveArray2ArrayReference(arrayObject);
+            } else {
+                return singleDimensionObjectArray2ObjectArrayReference(jvmClassLoader, arrayObject);
+            }
+        }
+
+        // multiple dimensions
+        throw new RuntimeException("Now cannot support multiple dimensions array");
+    }
+
+    /**
+     * @param primitiveArrayObject 1 dimension array of primitive type
+     * @return self-define array reference
+     */
+    public static BaseTypeArrayReference singleDimensionPrimitiveArray2ArrayReference(Object primitiveArrayObject) {
+        // get component type
+        final Class<?> type = primitiveArrayObject.getClass().getComponentType();
+        if(type.equals(boolean.class)) {
+            return new BaseTypeArrayReference((boolean[]) primitiveArrayObject);
+        } else if(type.equals(byte.class)) {
+            return new BaseTypeArrayReference((byte[]) primitiveArrayObject);
+        } else if(type.equals(short.class)) {
+            return new BaseTypeArrayReference((short[]) primitiveArrayObject);
+        } else if(type.equals(char.class)) {
+            return new BaseTypeArrayReference((char[]) primitiveArrayObject);
+        } else if(type.equals(int.class)) {
+            return new BaseTypeArrayReference((int[]) primitiveArrayObject);
+        } else if(type.equals(float.class)) {
+            return new BaseTypeArrayReference((float[]) primitiveArrayObject);
+        } else if(type.equals(long.class)) {
+            return new BaseTypeArrayReference((long[]) primitiveArrayObject);
+        } else if(type.equals(double.class)) {
+            return new BaseTypeArrayReference((double[]) primitiveArrayObject);
+        } else {
+            throw new IllegalArgumentException("Cannot set type " + type);
+        }
+    }
+
+    /**
+     * @param objectArrayObject 1 dimension array of object reference
+     * @return self-define array reference
+     */
+    public static ObjectArrayReference singleDimensionObjectArray2ObjectArrayReference(
+            JvmClassLoader jvmClassLoader, Object objectArrayObject
+    ) throws IllegalAccessException {
+        Object[] objects = (Object[]) objectArrayObject;
+        Class<?> componentClass = objects.getClass().getComponentType();
+        ObjectArrayReference objectArrayReference = new ObjectArrayReference(
+                jvmClassLoader.loadClass(componentClass),
+                objects.length
+        );
+        for(int i = 0; i < objects.length; i++) {
+            Reference reference = object2Reference(jvmClassLoader, objects[i]);
+            objectArrayReference.setReference(i, reference);
+        }
+        return objectArrayReference;
+    }
+
+    /**
+     * get all field from ancestor to current class
+     * keep the order
+     * @param clazz current class
+     * @return
+     */
+    private static List<Field> getAllFieldsFromAncestor(Class<?> clazz) {
+        List<Field> fields = new ArrayList<>();
+        for(Class<?> now = clazz; null != now; now = now.getSuperclass()) {
+            Field[] nowFields = now.getDeclaredFields();
+            // add from last to head
+            for(int i = nowFields.length - 1; i >= 0; i--) {
+                fields.add(nowFields[i]);
+            }
+        }
+        // remember to reverse the fields got
+        Collections.reverse(fields);
+        return fields;
+    }
+
+    /**
+     * get all non static fields of a class (from ancestor to current)
+     * keep the order
+     * @param clazz
+     * @return
+     */
+    private static List<Field> getNonStaticFieldsFromAncestor(Class<?> clazz) {
+        List<Field> nonStaticFields = new ArrayList<>();
+        List<Field> allFields = getAllFieldsFromAncestor(clazz);
+        for(Field field : allFields) {
+            if(!Modifier.isStatic(field.getModifiers())) {
+                nonStaticFields.add(field);
+            }
+        }
+        return nonStaticFields;
+    }
+
+    /**
+     * get all static fields of a class (from ancestor to current)
+     * keep the order
+     * @param clazz
+     * @return
+     */
+    private static List<Field> getStaticFieldsFromAncestor(Class<?> clazz) {
+        List<Field> nonStaticFields = new ArrayList<>();
+        List<Field> allFields = getAllFieldsFromAncestor(clazz);
+        for(Field field : allFields) {
+            if(Modifier.isStatic(field.getModifiers())) {
+                nonStaticFields.add(field);
+            }
+        }
+        return nonStaticFields;
+    }
+
+    /**
+     * the field's size in local variables and operand stack
+     * long and double will occupy 2 size
+     * other is 1
+     * @param field
+     * @return
+     */
+    private static int getFieldSize(Field field) {
+        Class<?> fieldType = field.getType();
+        if(fieldType.equals(long.class)
+        || fieldType.equals(double.class)) {
+            return 2;
+        } else {
+            return 1;
+        }
+    }
+
+    /**
+     * set the field's value to position offset
+     * long and double will occupy 2 locations
+     * @param localVariables super class of ObjectReference
+     * @param offset position in the object
+     * @param field must be primitive type
+     */
+    private static void setPrimitiveType(LocalVariables localVariables, int offset, Object object, Field field) throws IllegalAccessException {
+        field.setAccessible(true);
+        final Class<?> fieldType = field.getType();
+        final Class<?> type = fieldType;
+        if(type.equals(boolean.class)) {
+            boolean value = field.getBoolean(object);
+            localVariables.setBooleanValue(offset, value);
+        } else if(type.equals(byte.class)) {
+            byte value = field.getByte(object);
+            localVariables.setByteValue(offset, value);
+        } else if(type.equals(short.class)) {
+            short value = field.getShort(object);
+            localVariables.setShortValue(offset, value);
+        } else if(type.equals(char.class)) {
+            char value = field.getChar(object);
+            localVariables.setCharValue(offset, value);
+        } else if(type.equals(int.class)) {
+            int value = field.getInt(object);
+            localVariables.setIntValue(offset, value);
+        } else if(type.equals(float.class)) {
+            float value = field.getFloat(object);
+            localVariables.setFloatValue(offset, value);
+        } else if(type.equals(long.class)) {
+            long value = field.getLong(object);
+            localVariables.setLongValue(offset, value);
+        } else if(type.equals(double.class)) {
+            double value = field.getDouble(object);
+            localVariables.setDoubleValue(offset, value);
+        } else {
+            throw new IllegalArgumentException("Cannot set type " + type);
+        }
+    }
+
+
+    /**
+     * set the value to position offset
+     * according to the value's type
+     * the value must can unpack to primitive value
+     * @param type value's type
+     * @param baseTypeArrayReference
+     * @param offset
+     * @param value primitive type value
+     */
+    private static void setPrimitiveType(
+            Class<?> type,
+            BaseTypeArrayReference baseTypeArrayReference, int offset,
+            Object value) {
+        if(type.equals(boolean.class)) {
+            baseTypeArrayReference.setBooleanValue(offset, (Boolean) value);
+        } else if(type.equals(byte.class)) {
+            baseTypeArrayReference.setByteValue(offset, (Byte) value);
+        } else if(type.equals(short.class)) {
+            baseTypeArrayReference.setShortValue(offset, (Short) value);
+        } else if(type.equals(char.class)) {
+            baseTypeArrayReference.setCharValue(offset, (Character) value);
+        } else if(type.equals(int.class)) {
+            baseTypeArrayReference.setIntValue(offset, (Integer) value);
+        } else if(type.equals(float.class)) {
+            baseTypeArrayReference.setFloatValue(offset, (Float) value);
+        } else if(type.equals(long.class)) {
+            baseTypeArrayReference.setLongValue(offset, (Long) value);
+        } else if(type.equals(double.class)) {
+            baseTypeArrayReference.setDoubleValue(offset, (Double) value);
+        } else {
+            throw new IllegalArgumentException("Cannot set type " + type);
+        }
+    }
+
+
+    /**
+     * set the value to position offset
+     * according to the value's type
+     * the value must be object reference
+     * @param localVariables
+     * @param fieldCurrentOffset
+     * @param jvmClassLoader
+     * @param object
+     * @param field
+     */
+    private static void setReferenceType(
+            LocalVariables localVariables, int fieldCurrentOffset,
+            JvmClassLoader jvmClassLoader,
+            Object object, Field field
+    ) throws IllegalAccessException {
+        // get the field
+        field.setAccessible(true);
+        Object fieldObject = field.get(object);
+        // resolve the reference
+        Reference reference = object2Reference(jvmClassLoader, fieldObject);
+        // set the reference
+        localVariables.setReference(fieldCurrentOffset, reference);
+    }
 }

--- a/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
@@ -71,7 +71,7 @@ public class ReferenceUtils {
      * @return
      * @throws IllegalAccessException
      */
-    public static Reference object2ObjectReference(
+    public static ObjectReference object2ObjectReference(
             JvmClassLoader jvmClassLoader, Object object
     ) throws IllegalAccessException {
         final Class<?> clazz = object.getClass();
@@ -82,7 +82,7 @@ public class ReferenceUtils {
         // converter the static fields, todo
 
         // converter the non-static fields
-        List<Field> nonStaticFields = getNonStaticFieldsFromAncestor(clazz);
+        List<Field> nonStaticFields = ReflectionUtils.getNonStaticFieldsFromAncestor(clazz);
         int nonStaticFieldCurrentOffset = 0;
         for(Field nonStaticField : nonStaticFields) {
             if(nonStaticField.getType().isPrimitive()) {
@@ -90,7 +90,7 @@ public class ReferenceUtils {
             } else {
                 setReferenceType(objectReference, nonStaticFieldCurrentOffset, jvmClassLoader, object, nonStaticField);
             }
-            nonStaticFieldCurrentOffset += getFieldSize(nonStaticField);
+            nonStaticFieldCurrentOffset += ReflectionUtils.getFieldSize(nonStaticField);
         }
 
         return objectReference;
@@ -168,77 +168,6 @@ public class ReferenceUtils {
             objectArrayReference.setReference(i, reference);
         }
         return objectArrayReference;
-    }
-
-    /**
-     * get all field from ancestor to current class
-     * keep the order
-     * @param clazz current class
-     * @return
-     */
-    private static List<Field> getAllFieldsFromAncestor(Class<?> clazz) {
-        List<Field> fields = new ArrayList<>();
-        for(Class<?> now = clazz; null != now; now = now.getSuperclass()) {
-            Field[] nowFields = now.getDeclaredFields();
-            // add from last to head
-            for(int i = nowFields.length - 1; i >= 0; i--) {
-                fields.add(nowFields[i]);
-            }
-        }
-        // remember to reverse the fields got
-        Collections.reverse(fields);
-        return fields;
-    }
-
-    /**
-     * get all non static fields of a class (from ancestor to current)
-     * keep the order
-     * @param clazz
-     * @return
-     */
-    private static List<Field> getNonStaticFieldsFromAncestor(Class<?> clazz) {
-        List<Field> nonStaticFields = new ArrayList<>();
-        List<Field> allFields = getAllFieldsFromAncestor(clazz);
-        for(Field field : allFields) {
-            if(!Modifier.isStatic(field.getModifiers())) {
-                nonStaticFields.add(field);
-            }
-        }
-        return nonStaticFields;
-    }
-
-    /**
-     * get all static fields of a class (from ancestor to current)
-     * keep the order
-     * @param clazz
-     * @return
-     */
-    private static List<Field> getStaticFieldsFromAncestor(Class<?> clazz) {
-        List<Field> nonStaticFields = new ArrayList<>();
-        List<Field> allFields = getAllFieldsFromAncestor(clazz);
-        for(Field field : allFields) {
-            if(Modifier.isStatic(field.getModifiers())) {
-                nonStaticFields.add(field);
-            }
-        }
-        return nonStaticFields;
-    }
-
-    /**
-     * the field's size in local variables and operand stack
-     * long and double will occupy 2 size
-     * other is 1
-     * @param field
-     * @return
-     */
-    private static int getFieldSize(Field field) {
-        Class<?> fieldType = field.getType();
-        if(fieldType.equals(long.class)
-        || fieldType.equals(double.class)) {
-            return 2;
-        } else {
-            return 1;
-        }
     }
 
     /**
@@ -394,7 +323,7 @@ public class ReferenceUtils {
             throw new RuntimeException(e);
         }
         final JvmClassLoader jvmClassLoader = objectReference.getJvmClass().getLoader();
-        List<Field> fields = ReferenceUtils.getNonStaticFieldsFromAncestor(clazz);
+        List<Field> fields = ReflectionUtils.getNonStaticFieldsFromAncestor(clazz);
         int realOffset = 0;
         for(int i = 0; i < fields.size(); i++) {
             Field field = fields.get(i);
@@ -403,7 +332,7 @@ public class ReferenceUtils {
             } else {
                 setReference2ObjectField(object, field, jvmClassLoader, objectReference, realOffset);
             }
-            realOffset += getFieldSize(field);
+            realOffset += ReflectionUtils.getFieldSize(field);
         }
         return object;
     }

--- a/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
@@ -1,14 +1,12 @@
 package com.github.anilople.javajvm.utils;
 
 import com.github.anilople.javajvm.cachepool.StringPool;
+import com.github.anilople.javajvm.constants.ArrayTypeCodes;
 import com.github.anilople.javajvm.heap.JvmClass;
 import com.github.anilople.javajvm.heap.JvmClassLoader;
 import com.github.anilople.javajvm.runtimedataarea.LocalVariables;
 import com.github.anilople.javajvm.runtimedataarea.Reference;
-import com.github.anilople.javajvm.runtimedataarea.reference.ArrayReference;
-import com.github.anilople.javajvm.runtimedataarea.reference.BaseTypeArrayReference;
-import com.github.anilople.javajvm.runtimedataarea.reference.ObjectArrayReference;
-import com.github.anilople.javajvm.runtimedataarea.reference.ObjectReference;
+import com.github.anilople.javajvm.runtimedataarea.reference.*;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -328,5 +326,97 @@ public class ReferenceUtils {
         Reference reference = object2Reference(jvmClassLoader, fieldObject);
         // set the reference
         localVariables.setReference(fieldCurrentOffset, reference);
+    }
+
+    /**
+     * convert self-define reference to a real object
+     * @param reference
+     * @return
+     */
+    public static Object reference2Object(Reference reference) {
+        if(reference instanceof NullReference) {
+            return null;
+        } else if(reference instanceof ObjectReference) {
+            return objectReference2Object((ObjectReference) reference);
+        } else if(reference instanceof ArrayReference) {
+            return arrayReference2Object((ArrayReference) reference);
+        } else {
+            throw new IllegalStateException("Unexpected value: " + reference.toString());
+        }
+    }
+
+    private static Object objectReference2Object(ObjectReference objectReference) {
+        return null;
+    }
+
+    private static Object arrayReference2Object(ArrayReference arrayReference) {
+        if(arrayReference instanceof BaseTypeArrayReference) {
+            return baseTypeArrayReference2Object((BaseTypeArrayReference) arrayReference);
+        } else if(arrayReference instanceof ObjectArrayReference) {
+            return objectArrayReference2Object((ObjectArrayReference) arrayReference);
+        } else {
+            throw new IllegalStateException("Unexpected value: " + arrayReference.toString());
+        }
+    }
+
+    public static Object baseTypeArrayReference2Object(BaseTypeArrayReference baseTypeArrayReference) {
+        final int length = baseTypeArrayReference.length();
+        final byte typeCode = baseTypeArrayReference.getTypeCode();
+        switch (typeCode) {
+            case ArrayTypeCodes.T_BOOLEAN:
+                boolean[] booleans = new boolean[length];
+                for(int i = 0; i < length; i++) {
+                    booleans[i] = baseTypeArrayReference.getBooleanValue(i);
+                }
+                return booleans;
+            case ArrayTypeCodes.T_BYTE:
+                byte[] bytes = new byte[length];
+                for(int i = 0; i < length; i++) {
+                    bytes[i] = baseTypeArrayReference.getByteValue(i);
+                }
+                return bytes;
+            case ArrayTypeCodes.T_CHAR:
+                char[] chars = new char[length];
+                for(int i = 0; i < length; i++) {
+                    chars[i] = baseTypeArrayReference.getCharValue(i);
+                }
+                return chars;
+            case ArrayTypeCodes.T_DOUBLE:
+                double[] doubles = new double[length];
+                for(int i = 0; i < length; i++) {
+                    doubles[i] = baseTypeArrayReference.getDoubleValue(i);
+                }
+                return doubles;
+            case ArrayTypeCodes.T_FLOAT:
+                float[] floats = new float[length];
+                for(int i = 0; i < length; i++) {
+                    floats[i] = baseTypeArrayReference.getFloatValue(i);
+                }
+                return floats;
+            case ArrayTypeCodes.T_INT:
+                int[] ints = new int[length];
+                for(int i = 0; i < length; i++) {
+                    ints[i] = baseTypeArrayReference.getIntValue(i);
+                }
+                return ints;
+            case ArrayTypeCodes.T_LONG:
+                long[] longs = new long[length];
+                for(int i = 0; i < length; i++) {
+                    longs[i] = baseTypeArrayReference.getLongValue(i);
+                }
+                return longs;
+            case ArrayTypeCodes.T_SHORT:
+                short[] shorts = new short[length];
+                for(int i = 0; i < length; i++) {
+                    shorts[i] = baseTypeArrayReference.getShortValue(i);
+                }
+                return shorts;
+            default:
+                throw new IllegalStateException("Unexpected value: " + typeCode);
+        }
+    }
+
+    private static Object objectArrayReference2Object(ObjectArrayReference objectArrayReference) {
+        return null;
     }
 }

--- a/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/ReferenceUtils.java
@@ -535,4 +535,96 @@ public class ReferenceUtils {
             throw new IllegalArgumentException("Cannot set type " + type);
         }
     }
+
+    /**
+     * emulator "arraycopy" in System
+     * @see java.lang.System arraycopy
+     * @param src
+     * @param srcPos
+     * @param dest
+     * @param destPos
+     * @param length
+     */
+    public static void arrayCopy(
+            ArrayReference src, int srcPos,
+            ArrayReference dest, int destPos,
+            int length
+    ) {
+        if(!src.getClass().equals(dest.getClass())) {
+            throw new IllegalArgumentException(src + " type not same as " + dest);
+        }
+        if(src instanceof BaseTypeArrayReference) {
+            arrayCopy((BaseTypeArrayReference) src, srcPos, (BaseTypeArrayReference) dest, destPos, length);
+        } else if(src instanceof ObjectArrayReference) {
+            throw new RuntimeException("Now cannot support array copy " + ObjectArrayReference.class);
+        } else {
+            throw new IllegalStateException("Wrong type " + src);
+        }
+    }
+
+    /**
+     * copy the primitive values of self-define bast type array
+     * @param src
+     * @param srcPos
+     * @param dest
+     * @param destPos
+     * @param length
+     */
+    private static void arrayCopy(
+            BaseTypeArrayReference src, int srcPos,
+            BaseTypeArrayReference dest, int destPos,
+            int length
+    ) {
+        if(src.getTypeCode() != dest.getTypeCode()) {
+            throw new IllegalArgumentException("type code not same");
+        }
+        for(int i = 0; i < length; i++) {
+            arrayCopyPrimitiveOne(src, srcPos + i, dest, destPos + i);
+        }
+    }
+
+    /**
+     * just copy 1 primitive element in array
+     * @param src
+     * @param srcIndex
+     * @param dest
+     * @param destIndex
+     */
+    private static void arrayCopyPrimitiveOne(
+            BaseTypeArrayReference src, int srcIndex,
+            BaseTypeArrayReference dest, int destIndex
+    ) {
+        if(src.getTypeCode() != dest.getTypeCode()) {
+            throw new IllegalArgumentException("type code not same");
+        }
+        final byte typeCode = src.getTypeCode();
+        switch (typeCode) {
+            case ArrayTypeCodes.T_BOOLEAN:
+                dest.setBooleanValue(destIndex, src.getBooleanValue(srcIndex));
+                break;
+            case ArrayTypeCodes.T_BYTE:
+                dest.setByteValue(destIndex, src.getByteValue(srcIndex));
+                break;
+            case ArrayTypeCodes.T_CHAR:
+                dest.setCharValue(destIndex, src.getCharValue(srcIndex));
+                break;
+            case ArrayTypeCodes.T_DOUBLE:
+                dest.setDoubleValue(destIndex, src.getDoubleValue(srcIndex));
+                break;
+            case ArrayTypeCodes.T_FLOAT:
+                dest.setFloatValue(destIndex, src.getFloatValue(srcIndex));
+                break;
+            case ArrayTypeCodes.T_INT:
+                dest.setIntValue(destIndex, src.getIntValue(srcIndex));
+                break;
+            case ArrayTypeCodes.T_LONG:
+                dest.setLongValue(destIndex, src.getLongValue(srcIndex));
+                break;
+            case ArrayTypeCodes.T_SHORT:
+                dest.setShortValue(destIndex, src.getShortValue(srcIndex));
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + typeCode);
+        }
+    }
 }

--- a/src/main/java/com/github/anilople/javajvm/utils/ReflectionUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/ReflectionUtils.java
@@ -127,4 +127,21 @@ public class ReflectionUtils {
         }
         return clazz;
     }
+
+    /**
+     * calculate the field's offset in class
+     * @param clazz
+     * @param fieldName
+     * @return
+     */
+    public static int getNonStaticOffset(Class<?> clazz, String fieldName) {
+        int offset = 0;
+        for(Field field : ReflectionUtils.getNonStaticFieldsFromAncestor(clazz)) {
+            if(field.getName().equals(fieldName)) {
+                return offset;
+            }
+            offset += ReflectionUtils.getFieldSize(field);
+        }
+        throw new RuntimeException("field name " + fieldName + " not in class " + clazz);
+    }
 }

--- a/src/main/java/com/github/anilople/javajvm/utils/ReflectionUtils.java
+++ b/src/main/java/com/github/anilople/javajvm/utils/ReflectionUtils.java
@@ -1,0 +1,130 @@
+package com.github.anilople.javajvm.utils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * reflection utils
+ * handle runtime
+ * Must not interact with self-define reference !!! 
+ */
+public class ReflectionUtils {
+
+    /**
+     * the type's size in local variables and operand stack
+     * long and double will occupy 2 size
+     * other is 1
+     * @param clazz
+     * @return
+     */
+    public static int getClassSize(Class<?> clazz) {
+        if(clazz.equals(long.class) || clazz.equals(double.class)) {
+            return 2;
+        } else {
+            return 1;
+        }
+    }
+
+    /**
+     * the field's size in local variables and operand stack
+     * long and double will occupy 2 size
+     * other is 1
+     * @param field
+     * @return
+     */
+    public static int getFieldSize(Field field) {
+        Class<?> fieldType = field.getType();
+        return getClassSize(fieldType);
+    }
+
+
+    /**
+     * get all field from ancestor to current class
+     * keep the order
+     * @param clazz current class
+     * @return
+     */
+    public static List<Field> getAllFieldsFromAncestor(Class<?> clazz) {
+        List<Field> fields = new ArrayList<>();
+        for(Class<?> now = clazz; null != now; now = now.getSuperclass()) {
+            Field[] nowFields = now.getDeclaredFields();
+            // add from last to head
+            for(int i = nowFields.length - 1; i >= 0; i--) {
+                fields.add(nowFields[i]);
+            }
+        }
+        // remember to reverse the fields got
+        Collections.reverse(fields);
+        return fields;
+    }
+
+    /**
+     * get all non static fields of a class (from ancestor to current)
+     * keep the order
+     * @param clazz
+     * @return
+     */
+    public static List<Field> getNonStaticFieldsFromAncestor(Class<?> clazz) {
+        List<Field> nonStaticFields = new ArrayList<>();
+        List<Field> allFields = getAllFieldsFromAncestor(clazz);
+        for(Field field : allFields) {
+            if(!Modifier.isStatic(field.getModifiers())) {
+                nonStaticFields.add(field);
+            }
+        }
+        return nonStaticFields;
+    }
+
+    /**
+     * get all static fields of a class (from ancestor to current)
+     * keep the order
+     * @param clazz
+     * @return
+     */
+    public static List<Field> getStaticFieldsFromAncestor(Class<?> clazz) {
+        List<Field> nonStaticFields = new ArrayList<>();
+        List<Field> allFields = getAllFieldsFromAncestor(clazz);
+        for(Field field : allFields) {
+            if(Modifier.isStatic(field.getModifiers())) {
+                nonStaticFields.add(field);
+            }
+        }
+        return nonStaticFields;
+    }
+
+    /**
+     * get the primitive class
+     * boolean.class
+     * byte.class
+     * short.class
+     * char.class
+     * int.class
+     * long.class
+     * float.class
+     * double.class
+     * @see java.lang.Class
+     * @param name
+     * @return
+     */
+    public static Class<?> getPrimitiveClass(String name) {
+        Method method = null;
+        try {
+            method = Class.class.getDeclaredMethod("getPrimitiveClass", String.class);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        method.setAccessible(true);
+        Class<?> clazz = null;
+        try {
+            clazz = (Class<?>) method.invoke(null, name);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+        return clazz;
+    }
+}

--- a/src/test/java/com/github/anilople/javajvm/helper/OperandStacksHelper.java
+++ b/src/test/java/com/github/anilople/javajvm/helper/OperandStacksHelper.java
@@ -31,7 +31,8 @@ public class OperandStacksHelper {
         consumer.accept(value);
         operandStacks.pushShortValue(value);
     }
-    public static void checkTopInteger(OperandStacks operandStacks, Consumer<Integer> consumer) {
+
+    public static void checkTopInt(OperandStacks operandStacks, Consumer<Integer> consumer) {
         int value = operandStacks.popIntValue();
         consumer.accept(value);
         operandStacks.pushIntValue(value);

--- a/src/test/java/com/github/anilople/javajvm/instructions/control/DRETURNTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/control/DRETURNTest.java
@@ -1,0 +1,42 @@
+package com.github.anilople.javajvm.instructions.control;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DRETURNTest {
+
+    private static double doubleReturn() {
+        return 1.66D;
+    }
+
+    public static void main(String[] args) {
+        double value = doubleReturn();
+    }
+
+    @Test
+    void execute() {
+        final BiConsumer<Instruction, JvmThread> after = (instruction, jvmThread) -> {
+            assertEquals(DRETURN.class, instruction.getClass());
+            OperandStacksHelper.checkTopDouble(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aDouble -> assertEquals(aDouble, 1.66D)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+
+        jvmThreadRunner.addAfterInstructionExecutionListener(DRETURN.class, after);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(DRETURN.class));
+    }
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/control/FRETURNTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/control/FRETURNTest.java
@@ -1,0 +1,42 @@
+package com.github.anilople.javajvm.instructions.control;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FRETURNTest {
+
+    private static float floatReturn() {
+        return 0.777F;
+    }
+
+    public static void main(String[] args) {
+        float value = floatReturn();
+    }
+
+    @Test
+    void execute() {
+        final BiConsumer<Instruction, JvmThread> after = (instruction, jvmThread) -> {
+            assertEquals(FRETURN.class, instruction.getClass());
+            OperandStacksHelper.checkTopFloat(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aFloat -> assertEquals(aFloat, 0.777F)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+
+        jvmThreadRunner.addAfterInstructionExecutionListener(FRETURN.class, after);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(FRETURN.class));
+    }
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/control/LRETURNTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/control/LRETURNTest.java
@@ -1,0 +1,42 @@
+package com.github.anilople.javajvm.instructions.control;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LRETURNTest {
+
+    private static long longReturn() {
+        return 123456789011L;
+    }
+
+    public static void main(String[] args) {
+        long value = longReturn();
+    }
+
+    @Test
+    void execute() {
+        final BiConsumer<Instruction, JvmThread> after = (instruction, jvmThread) -> {
+            assertEquals(LRETURN.class, instruction.getClass());
+            OperandStacksHelper.checkTopLong(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aLong -> assertEquals(aLong, 123456789011L)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+
+        jvmThreadRunner.addAfterInstructionExecutionListener(LRETURN.class, after);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(LRETURN.class));
+    }
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/math/bitwiseand/IANDTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/math/bitwiseand/IANDTest.java
@@ -1,0 +1,39 @@
+package com.github.anilople.javajvm.instructions.math.bitwiseand;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IANDTest {
+
+    public static void main(String[] args) {
+        int a = 0xF000_FFFF;
+        int b = 0xFFFF_000F;
+        int c = a & b;
+    }
+
+    @Test
+    void execute() {
+        final BiConsumer<Instruction, JvmThread> afterListener = (instruction, jvmThread) -> {
+            assertEquals(instruction.getClass(), IAND.class);
+            OperandStacksHelper.checkTopInt(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aInt -> assertEquals(aInt, 0xF000_000F)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+        jvmThreadRunner.addAfterInstructionExecutionListener(IAND.class, afterListener);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(IAND.class));
+    }
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/math/bitwiseand/LANDTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/math/bitwiseand/LANDTest.java
@@ -1,0 +1,44 @@
+package com.github.anilople.javajvm.instructions.math.bitwiseand;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Native;
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LANDTest {
+
+    public static void main(String[] args) {
+        // value copy from Long.MIN_VALUE
+        long min = 0x8000000000000000L;
+        // value copy from Long.MAX_VALUE
+        long max = 0x7fffffffffffffffL;
+
+        long value = min & max;
+    }
+
+    @Test
+    void execute() {
+        final BiConsumer<Instruction, JvmThread> afterListener = (instruction, jvmThread) -> {
+            assertEquals(instruction.getClass(), LAND.class);
+            OperandStacksHelper.checkTopLong(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aLong -> assertEquals(aLong, 0)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+        jvmThreadRunner.addAfterInstructionExecutionListener(LAND.class, afterListener);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(LAND.class));
+    }
+
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/math/shift/ISHLTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/math/shift/ISHLTest.java
@@ -1,0 +1,41 @@
+package com.github.anilople.javajvm.instructions.math.shift;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ISHLTest {
+
+    public static void main(String[] args) {
+        int value1 = 1;
+        int value2 = 3;
+        int after = value1 << value2;
+    }
+
+    @Test
+    void execute() {
+
+        final BiConsumer<Instruction, JvmThread> afterListener = (instruction, jvmThread) -> {
+            assertEquals(instruction.getClass(), ISHL.class);
+            OperandStacksHelper.checkTopInt(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aInt -> assertEquals(aInt, 8)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+
+        jvmThreadRunner.addAfterInstructionExecutionListener(ISHL.class, afterListener);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(ISHL.class));
+    }
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/math/shift/ISHRTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/math/shift/ISHRTest.java
@@ -1,0 +1,42 @@
+package com.github.anilople.javajvm.instructions.math.shift;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ISHRTest {
+
+    public static void main(String[] args) {
+        int value1 = -1;
+        int value2 = 3;
+        int after = value1 >> value2;
+    }
+
+    @Test
+    void execute() {
+
+        final BiConsumer<Instruction, JvmThread> afterListener = (instruction, jvmThread) -> {
+            assertEquals(instruction.getClass(), ISHR.class);
+            OperandStacksHelper.checkTopInt(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aInt -> assertEquals(aInt, -1)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+
+        jvmThreadRunner.addAfterInstructionExecutionListener(ISHR.class, afterListener);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(ISHR.class));
+    }
+    
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/math/shift/IUSHRTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/math/shift/IUSHRTest.java
@@ -1,0 +1,42 @@
+package com.github.anilople.javajvm.instructions.math.shift;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IUSHRTest {
+
+    public static void main(String[] args) {
+        int value1 = -1;
+        int value2 = 1;
+        int after = value1 >>> value2;
+    }
+
+    @Test
+    void execute() {
+
+        final BiConsumer<Instruction, JvmThread> afterListener = (instruction, jvmThread) -> {
+            assertEquals(instruction.getClass(), IUSHR.class);
+            OperandStacksHelper.checkTopInt(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aInt -> assertEquals(aInt, Integer.MAX_VALUE)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+
+        jvmThreadRunner.addAfterInstructionExecutionListener(IUSHR.class, afterListener);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(IUSHR.class));
+    }
+    
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/math/shift/LSHLTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/math/shift/LSHLTest.java
@@ -1,0 +1,42 @@
+package com.github.anilople.javajvm.instructions.math.shift;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LSHLTest {
+
+    public static void main(String[] args) {
+        long value1 = 1;
+        int value2 = 3;
+        long after = value1 << value2;
+    }
+
+    @Test
+    void execute() {
+
+        final BiConsumer<Instruction, JvmThread> afterListener = (instruction, jvmThread) -> {
+            assertEquals(instruction.getClass(), LSHL.class);
+            OperandStacksHelper.checkTopLong(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aLong -> assertEquals(aLong, 8)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+
+        jvmThreadRunner.addAfterInstructionExecutionListener(LSHL.class, afterListener);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(LSHL.class));
+    }
+
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/math/shift/LSHRTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/math/shift/LSHRTest.java
@@ -1,0 +1,42 @@
+package com.github.anilople.javajvm.instructions.math.shift;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LSHRTest {
+
+    public static void main(String[] args) {
+        long value1 = -1;
+        int value2 = 3;
+        long after = value1 >> value2;
+    }
+
+    @Test
+    void execute() {
+
+        final BiConsumer<Instruction, JvmThread> afterListener = (instruction, jvmThread) -> {
+            assertEquals(instruction.getClass(), LSHR.class);
+            OperandStacksHelper.checkTopLong(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aLong -> assertEquals(aLong, -1)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+
+        jvmThreadRunner.addAfterInstructionExecutionListener(LSHR.class, afterListener);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(LSHR.class));
+    }
+    
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/math/shift/LUSHRTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/math/shift/LUSHRTest.java
@@ -1,0 +1,42 @@
+package com.github.anilople.javajvm.instructions.math.shift;
+
+import com.github.anilople.javajvm.helper.JvmThreadFactory;
+import com.github.anilople.javajvm.helper.JvmThreadRunner;
+import com.github.anilople.javajvm.helper.OperandStacksHelper;
+import com.github.anilople.javajvm.instructions.Instruction;
+import com.github.anilople.javajvm.runtimedataarea.JvmThread;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LUSHRTest {
+
+    public static void main(String[] args) {
+        long value1 = -1;
+        int value2 = 1;
+        long after = value1 >>> value2;
+    }
+
+    @Test
+    void execute() {
+
+        final BiConsumer<Instruction, JvmThread> afterListener = (instruction, jvmThread) -> {
+            assertEquals(instruction.getClass(), LUSHR.class);
+            OperandStacksHelper.checkTopLong(
+                    jvmThread.currentFrame().getOperandStacks(),
+                    aLong -> assertEquals(aLong, Long.MAX_VALUE)
+            );
+        };
+
+        JvmThreadRunner jvmThreadRunner = new JvmThreadRunner(JvmThreadFactory.makeSimpleInstance(this.getClass()));
+
+        jvmThreadRunner.addAfterInstructionExecutionListener(LUSHR.class, afterListener);
+
+        jvmThreadRunner.run();
+
+        assertTrue(jvmThreadRunner.isExecuted(LUSHR.class));
+    }
+
+}

--- a/src/test/java/com/github/anilople/javajvm/instructions/references/ANEWARRAYTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/references/ANEWARRAYTest.java
@@ -1,5 +1,6 @@
 package com.github.anilople.javajvm.instructions.references;
 
+import com.github.anilople.javajvm.heap.JvmClass;
 import com.github.anilople.javajvm.helper.HighOrderFunctions;
 import com.github.anilople.javajvm.helper.JvmThreadFactory;
 import com.github.anilople.javajvm.helper.JvmThreadRunner;
@@ -25,8 +26,8 @@ class ANEWARRAYTest {
             // in the ANEWARRAYTest's "main" method, so after Instruction "ANEWARRAY",
             ObjectArrayReference objectArrayReference = (ObjectArrayReference) jvmThread.currentFrame().getOperandStacks().popReference();
             // the top Object on the operand stack must be the array of "ANEWARRAYTest"
-            ObjectReference typeReference = (ObjectReference) objectArrayReference.getComponentTypeReference();
-            assertTrue(typeReference.getJvmClass().isSameName(ANEWARRAYTest.class));
+            JvmClass componentType = objectArrayReference.getComponentType();
+            assertTrue(componentType.isSameName(ANEWARRAYTest.class));
             // remember that push it back
             jvmThread.currentFrame().getOperandStacks().pushReference(objectArrayReference);
         };

--- a/src/test/java/com/github/anilople/javajvm/instructions/references/ANEWARRAYTest.java
+++ b/src/test/java/com/github/anilople/javajvm/instructions/references/ANEWARRAYTest.java
@@ -25,7 +25,7 @@ class ANEWARRAYTest {
             // in the ANEWARRAYTest's "main" method, so after Instruction "ANEWARRAY",
             ObjectArrayReference objectArrayReference = (ObjectArrayReference) jvmThread.currentFrame().getOperandStacks().popReference();
             // the top Object on the operand stack must be the array of "ANEWARRAYTest"
-            ObjectReference typeReference = (ObjectReference) objectArrayReference.getTypeReference();
+            ObjectReference typeReference = (ObjectReference) objectArrayReference.getComponentTypeReference();
             assertTrue(typeReference.getJvmClass().isSameName(ANEWARRAYTest.class));
             // remember that push it back
             jvmThread.currentFrame().getOperandStacks().pushReference(objectArrayReference);

--- a/src/test/java/com/github/anilople/javajvm/testcode/StringTest.java
+++ b/src/test/java/com/github/anilople/javajvm/testcode/StringTest.java
@@ -17,5 +17,6 @@ public class StringTest {
         String a = "test34234";
         String b = a;
         String c = a + b;
+        System.out.println(c);
     }
 }

--- a/src/test/java/com/github/anilople/javajvm/utils/DescriptorUtilsTest.java
+++ b/src/test/java/com/github/anilople/javajvm/utils/DescriptorUtilsTest.java
@@ -1,7 +1,9 @@
 package com.github.anilople.javajvm.utils;
 
+import com.github.anilople.javajvm.constants.Descriptors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import sun.security.krb5.internal.crypto.Des;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -53,5 +55,47 @@ class DescriptorUtilsTest {
 
     @Test
     void getClassName() {
+    }
+
+    @Test
+    void methodDescriptor2ParameterTypes() {
+        String methodDescriptor = "(I[ZLjava/lang/String;)I";
+        Class<?>[] classes = DescriptorUtils.methodDescriptor2ParameterTypes(methodDescriptor);
+        assertEquals(int.class, classes[0]);
+        assertEquals(boolean[].class, classes[1]);
+        assertEquals(String.class, classes[2]);
+    }
+
+    @Test
+    void fieldTypeDescriptor2Class() {
+        assertEquals(int.class, DescriptorUtils.fieldTypeDescriptor2Class("I"));
+        assertEquals(int[][][].class, DescriptorUtils.fieldTypeDescriptor2Class("[[[I"));
+        assertEquals(String[].class, DescriptorUtils.fieldTypeDescriptor2Class("[Ljava/lang/String;"));
+
+    }
+
+    @Test
+    void baseTypeDescriptor2Class() {
+        assertEquals(boolean.class, DescriptorUtils.baseTypeDescriptor2Class(Descriptors.BaseType.BOOLEAN));
+        assertEquals(byte.class, DescriptorUtils.baseTypeDescriptor2Class(Descriptors.BaseType.BYTE));
+        assertEquals(short.class, DescriptorUtils.baseTypeDescriptor2Class(Descriptors.BaseType.SHORT));
+        assertEquals(char.class, DescriptorUtils.baseTypeDescriptor2Class(Descriptors.BaseType.CHAR));
+        assertEquals(int.class, DescriptorUtils.baseTypeDescriptor2Class(Descriptors.BaseType.INT));
+        assertEquals(long.class, DescriptorUtils.baseTypeDescriptor2Class(Descriptors.BaseType.LONG));
+        assertEquals(float.class, DescriptorUtils.baseTypeDescriptor2Class(Descriptors.BaseType.FLOAT));
+        assertEquals(double.class, DescriptorUtils.baseTypeDescriptor2Class(Descriptors.BaseType.DOUBLE));
+    }
+
+    @Test
+    void arrayTypeDescriptor2Class() {
+        assertEquals(int[].class, DescriptorUtils.arrayTypeDescriptor2Class("[I"));
+        assertEquals(int[][][].class, DescriptorUtils.arrayTypeDescriptor2Class("[[[I"));
+        assertEquals(String[].class, DescriptorUtils.arrayTypeDescriptor2Class("[Ljava/lang/String;"));
+    }
+
+    @Test
+    void objectTypeDescriptor2Class() {
+        assertEquals(Object.class, DescriptorUtils.objectTypeDescriptor2Class("Ljava/lang/Object;"));
+        assertEquals(String.class, DescriptorUtils.objectTypeDescriptor2Class("Ljava/lang/String;"));
     }
 }

--- a/src/test/java/com/github/anilople/javajvm/utils/ReferenceUtilsTest.java
+++ b/src/test/java/com/github/anilople/javajvm/utils/ReferenceUtilsTest.java
@@ -88,4 +88,26 @@ class ReferenceUtilsTest {
             assertEquals(s.charAt(i), charArray.getCharValue(i));
         }
     }
+
+    @Test
+    void baseTypeArrayReference2Object_Char() {
+        char[] chars = new char[]{'a', '1', '+'};
+        BaseTypeArrayReference baseTypeArrayReference = ReferenceUtils.singleDimensionPrimitiveArray2ArrayReference(chars);
+        char[] charsImage = (char[]) ReferenceUtils.baseTypeArrayReference2Object(baseTypeArrayReference);
+        assertEquals(chars.length, charsImage.length);
+        for(int i = 0; i < chars.length; i++) {
+            assertEquals(chars[i], charsImage[i]);
+        }
+    }
+
+    @Test
+    void baseTypeArrayReference2Object_Double() {
+        double[] doubles = new double[]{1.0D, 2.999999D, 6.666666D};
+        BaseTypeArrayReference baseTypeArrayReference = ReferenceUtils.singleDimensionPrimitiveArray2ArrayReference(doubles);
+        double[] doublesImage = (double[]) ReferenceUtils.baseTypeArrayReference2Object(baseTypeArrayReference);
+        assertEquals(doubles.length, doublesImage.length);
+        for(int i = 0; i < doubles.length; i++) {
+            assertEquals(doubles[i], doublesImage[i]);
+        }
+    }
 }

--- a/src/test/java/com/github/anilople/javajvm/utils/ReferenceUtilsTest.java
+++ b/src/test/java/com/github/anilople/javajvm/utils/ReferenceUtilsTest.java
@@ -110,4 +110,54 @@ class ReferenceUtilsTest {
             assertEquals(doubles[i], doublesImage[i]);
         }
     }
+
+    @Test
+    void objectReference2Object() throws IllegalAccessException {
+
+        Values values = new Values();
+
+        ObjectReference objectReference = (ObjectReference) ReferenceUtils.object2ObjectReference(jvmClassLoader, values);
+
+        Values valuesImage = (Values) ReferenceUtils.objectReference2Object(objectReference);
+
+        values.equals(valuesImage);
+
+        assertEquals(values.getIntValue(), valuesImage.getIntValue());
+        assertEquals(values.getLongValue(), valuesImage.getLongValue());
+        assertEquals(values.getDoubleValue(), valuesImage.getDoubleValue());
+        char[] valuesCharArray = values.getChars();
+        char[] valuesImageCharArray = valuesImage.getChars();
+        assertEquals(valuesCharArray.length, valuesImageCharArray.length);
+        for(int i = 0; i < valuesCharArray.length; i++) {
+            assertEquals(valuesCharArray[i], valuesImageCharArray[i]);
+        }
+    }
+}
+
+/**
+ * for the field test
+ * the inner class will exists 'this$0' field
+ * so declare it here
+ */
+class Values {
+    private int intValue = 3;
+    private long longValue = 666L;
+    private char[] chars = new char[]{'1', '+'};
+    private double doubleValue = 8.888D;
+
+    public int getIntValue() {
+        return intValue;
+    }
+
+    public long getLongValue() {
+        return longValue;
+    }
+
+    public char[] getChars() {
+        return chars;
+    }
+
+    public double getDoubleValue() {
+        return doubleValue;
+    }
 }

--- a/src/test/java/com/github/anilople/javajvm/utils/ReferenceUtilsTest.java
+++ b/src/test/java/com/github/anilople/javajvm/utils/ReferenceUtilsTest.java
@@ -1,0 +1,91 @@
+package com.github.anilople.javajvm.utils;
+
+import com.github.anilople.javajvm.heap.JvmClassLoader;
+import com.github.anilople.javajvm.helper.JvmClassLoaderFactory;
+import com.github.anilople.javajvm.runtimedataarea.Reference;
+import com.github.anilople.javajvm.runtimedataarea.reference.BaseTypeArrayReference;
+import com.github.anilople.javajvm.runtimedataarea.reference.ObjectArrayReference;
+import com.github.anilople.javajvm.runtimedataarea.reference.ObjectReference;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReferenceUtilsTest {
+
+    private static final JvmClassLoader jvmClassLoader = JvmClassLoaderFactory.getInstance();
+
+    @Test
+    void getStringObjectReference() {
+        final String utf8 = "abcd";
+        ObjectReference objectReference = ReferenceUtils.getStringObjectReference(
+                jvmClassLoader.loadClass(String.class),
+                utf8
+        );
+        BaseTypeArrayReference baseTypeArrayReference = (BaseTypeArrayReference) objectReference.getReference(0);
+        assertEquals(utf8.length(), baseTypeArrayReference.length());
+        for(int i = 0; i < utf8.length(); i++) {
+            assertEquals(utf8.charAt(i), baseTypeArrayReference.getCharValue(i));
+        }
+    }
+
+    @Test
+    void singleDimensionBooleanArray2ArrayReference() throws IllegalAccessException {
+        boolean[] booleans = new boolean[]{false, true, false};
+        BaseTypeArrayReference booleanArray = (BaseTypeArrayReference) ReferenceUtils.array2ArrayReference(jvmClassLoader, booleans);
+        for(int i = 0; i < booleans.length; i++) {
+            assertEquals(booleans[i], booleanArray.getBooleanValue(i));
+        }
+    }
+
+    @Test
+    void singleDimensionCharArray2ArrayReference() throws IllegalAccessException {
+        char[] chars = new char[]{'a', '1', '+'};
+        BaseTypeArrayReference charArray = (BaseTypeArrayReference) ReferenceUtils.array2ArrayReference(jvmClassLoader, chars);
+        for(int i = 0; i < chars.length; i++) {
+            assertEquals(chars[i], charArray.getCharValue(i));
+        }
+    }
+
+    @Test
+    void singleDimensionIntArray2ArrayReference() throws IllegalAccessException {
+        int[] ints = new int[]{-1, 2, 3, 5};
+        BaseTypeArrayReference intArray = (BaseTypeArrayReference) ReferenceUtils.array2ArrayReference(jvmClassLoader, ints);
+        for(int i = 0; i < ints.length; i++) {
+            assertEquals(ints[i], intArray.getIntValue(i));
+        }
+    }
+
+    @Test
+    void singleDimensionObjectArray2ObjectArrayReference() throws IllegalAccessException {
+        Object[] objects = new Object[]{"sdf", "hei"};
+        ObjectArrayReference objectArrayReference = ReferenceUtils.singleDimensionObjectArray2ObjectArrayReference(jvmClassLoader, objects);
+        assertEquals(objects.length, objectArrayReference.length());
+        ObjectReference a = (ObjectReference) objectArrayReference.getReference(0);
+        BaseTypeArrayReference aCharArray = (BaseTypeArrayReference) a.getReference(0);
+        assertEquals('d', aCharArray.getCharValue(1));
+
+        ObjectReference b = (ObjectReference) objectArrayReference.getReference(1);
+        BaseTypeArrayReference bCharArray = (BaseTypeArrayReference) b.getReference(0);
+        assertEquals('h', bCharArray.getCharValue(0));
+    }
+
+    @Test
+    void null2Reference() throws IllegalAccessException {
+        Reference reference = ReferenceUtils.object2Reference(jvmClassLoader, null);
+        assertEquals(reference, Reference.NULL);
+    }
+
+    @Test
+    void string2Reference() throws IllegalAccessException {
+        final String s = "abc";
+        Reference reference = ReferenceUtils.object2Reference(jvmClassLoader, s);
+        ObjectReference objectReference = (ObjectReference) reference;
+        assertTrue(objectReference.getJvmClass().isSameName(String.class));
+        // first field in string is char[], now get it
+        BaseTypeArrayReference charArray = (BaseTypeArrayReference) objectReference.getReference(0);
+        // check char values in char[]
+        for(int i = 0; i < s.length(); i++) {
+            assertEquals(s.charAt(i), charArray.getCharValue(i));
+        }
+    }
+}

--- a/src/test/java/com/github/anilople/javajvm/utils/ReflectionUtilsTest.java
+++ b/src/test/java/com/github/anilople/javajvm/utils/ReflectionUtilsTest.java
@@ -1,0 +1,26 @@
+package com.github.anilople.javajvm.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReflectionUtilsTest {
+
+    private int intValue;
+    private long longValue;
+    private char[] chars;
+    private static int staticInt;
+    private double doubleValue;
+    private boolean booleanValue;
+    private short shortValue;
+
+    @Test
+    void getNonStaticOffset() {
+        assertEquals(0, ReflectionUtils.getNonStaticOffset(this.getClass(), "intValue"));
+        assertEquals(1, ReflectionUtils.getNonStaticOffset(this.getClass(), "longValue"));
+        assertEquals(3, ReflectionUtils.getNonStaticOffset(this.getClass(), "chars"));
+        assertEquals(4, ReflectionUtils.getNonStaticOffset(this.getClass(), "doubleValue"));
+        assertEquals(6, ReflectionUtils.getNonStaticOffset(this.getClass(), "booleanValue"));
+        assertEquals(7, ReflectionUtils.getNonStaticOffset(this.getClass(), "shortValue"));
+    }
+}


### PR DESCRIPTION
It is a problem when jvm wants to invoke a native method.

The implemention is that hack the native method use `javajvm.utils.HackUtils`.

When meet a native method,
Convert self-define `javajvm.runtimedataarea.Reference` in parameters to real object in JVM,
then use those object to invoke the native method by reflection.
After invocation, convert real object to self-define `javajvm.runtimedataarea.Reference`.

There are still some problems, like in method `System.arraycopy`, the native invocation change the content in method paramters, but the `javajvm.utils.HackUtils` cannot capture that. (Need more support).