### PR TITLE
FixBug: NEW target jvm class resolved

### DIFF
--- a/src/main/java/com/github/anilople/javajvm/heap/constant/JvmConstantClass.java
+++ b/src/main/java/com/github/anilople/javajvm/heap/constant/JvmConstantClass.java
@@ -37,6 +37,16 @@ public class JvmConstantClass extends JvmConstant {
      */
     public JvmClass resolveJvmClass() {
         String jvmClassName = this.getName();
-        return this.getJvmClass().getLoader().loadClass(jvmClassName);
+        // remember that use "super" not "this"
+        return super.getJvmClass().getLoader().loadClass(jvmClassName);
+    }
+
+    /**
+     * same as {@link this#resolveJvmClass()}
+     * @see this#resolveJvmClass()
+     */
+    @Override
+    public JvmClass getJvmClass() {
+        return this.resolveJvmClass();
     }
 }

--- a/src/main/java/com/github/anilople/javajvm/instructions/references/NEW.java
+++ b/src/main/java/com/github/anilople/javajvm/instructions/references/NEW.java
@@ -59,13 +59,13 @@ public class NEW implements Instruction {
         JvmConstantClass jvmConstantClass = (JvmConstantClass) frame.getJvmMethod().getJvmClass().getJvmConstantPool().getJvmConstant(index);
 
         // some type cannot be allocated to an instance
-        if(jvmConstantClass.getJvmClass().isInterface()
-            || jvmConstantClass.getJvmClass().isAbstract()) {
-            throw new InstantiationError("cannot initial " + jvmConstantClass);
+        final JvmClass targetJvmClass = jvmConstantClass.resolveJvmClass();
+        if(targetJvmClass.isInterface()
+            || targetJvmClass.isAbstract()) {
+            throw new InstantiationError("cannot initial " + targetJvmClass);
         }
 
         // allocate an object without initial
-        JvmClass targetJvmClass = jvmConstantClass.resolveJvmClass();
         logger.debug("try to allocate an object: {}", targetJvmClass);
         ObjectReference objectReference = ObjectReference.makeObjectReference(targetJvmClass);
         frame.getOperandStacks().pushReference(objectReference);

--- a/src/test/java/com/github/anilople/javajvm/testcode/container/MapTest.java
+++ b/src/test/java/com/github/anilople/javajvm/testcode/container/MapTest.java
@@ -67,7 +67,8 @@ public class MapTest {
     private static void stringValueOfMap() {
         Map<String, Integer> map = new HashMap<>();
         map.put("a", 1);
-        String.valueOf(map);
+        String s = String.valueOf(map);
+        System.out.println(s);
     }
 
     @Test


### PR DESCRIPTION
fixed #7 

Bug in `com.github.anilople.javajvm.instructions.references.NEW#execute`.

```java
        // some type cannot be allocated to an instance
        if(jvmConstantClass.getJvmClass().isInterface()
            || jvmConstantClass.getJvmClass().isAbstract()) {
            throw new InstantiationError("cannot initial " + jvmConstantClass);
        }

        // allocate an object without initial
        JvmClass targetJvmClass = jvmConstantClass.resolveJvmClass();
```

The judgement of `isInterface` and `isAbstract` with the wrong `JvmClass`.